### PR TITLE
Bot pays successful contributors with donated Bitcoins 

### DIFF
--- a/ideas.md
+++ b/ideas.md
@@ -1,3 +1,19 @@
 # Ideas
 
  - Post each successful PR to twitter
+
+## Paying people for contributions
+It would be great using this bot for autonomous project management.
+Think of it like this:
+
+You have an awesome idea, but very limited time to work on it. However, you want this idea to be implemented as you and everyone else using it would still benefit immensely from it.
+So you go head and write down a functional requirement specifications document and put it on Github.
+You also integrate this bot into the repository.
+Once you're done, you create issues for that project that require an equal amout of work to be done for the contributor.
+
+Here comes the new part:
+The bot now registers the issues and requests donators that have an interest in this issue being solved to create [2 of 2 multisignature Bitcoin addresses](http://bitcoin.stackexchange.com/questions/3712/how-can-i-create-a-multi-signature-2-of-3-transaction).
+One private key being the bots, the other one being the donator's one.
+Is a multisignature address successfully created and money being sent to it by the donator, the bot automatically advertises the bounty in the relevant issue.
+
+If the issue is then linked and solved in a Pull-Request and ultimately accepted by votes, the donator and the bot agree on sending the money in the multisignature address to the person successfully creating the merged pull request.


### PR DESCRIPTION
Hi,

I hope I did not destroy the formating of `ideas.md` too much.

There is still a big question mark for this idea on how to create the bot's private key.
Because, if we just assign a private key and hardcode it into the source, any donator could just sent his money back, as the bot's key and his key would allow him to sign the multisignatur transaction.

But, I still think there is a way to do it.
One idea I had was that the bot can somehow deterministically create private keys depending on an Issues Github idea + a random salt.

Though the salt should then somehow be disclosed from the public and from the project owner.

So if any Cryptopro (which I'm not btw) has any idea on how to achieve this, then shot!
So I can enhance this PR.

Curious to hear your feedback.

Have a nice day.