### PR TITLE
Idea: add a scratchpad/ directory which auto-accepts PRs

### DIFF
--- a/ideas.md
+++ b/ideas.md
@@ -4,3 +4,4 @@
  - Post each successful PR to twitter
  - Add an HTTP interface to report current status, display logs, per-user voting stats, etc.
  - Auto-label each PR 'winning'/'losing' after a vote
+ - Have a scratchpad/ directory; any PR that only changes files in scratchpad/ is accepted automatically.


### PR DESCRIPTION
It would be cool if changes that didn't touch anything important were easier to accept. Maybe we could add a `scratchpad/` directory, and if a PR only touches files in `scratchpad/`, it gets auto-accepted?