### PR TITLE
Fix PR Vote tracking

### DIFF
--- a/voting.js
+++ b/voting.js
@@ -259,12 +259,13 @@ module.exports = function(config, gh) {
       pr = null;
     }
     if(!results) results = [];
+    if(!n) n = 0;
 
     f({
       user: config.user,
       repo: config.repo,
       number: pr ? pr.number : null,
-      page: n || 0,
+      page: n,
       per_page: 100
 
     }, function(err, res) {


### PR DESCRIPTION
When attempting to loop through all of the pages of the stargazers, n (current page) was undefined. As a result, the requests never completed properly, and anything depending on stargazers was never reached.