### PR TITLE
Add a public domain dedication

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,5 @@ exports.githubAuth = {type: "oauth", token: "YOUR_OAUTH_TOKEN"}
 **Autonomous Software License (ASL)**
 
 All property contained in this repo, including Intellectual Property, Financial Property, and Legal Property, is owned solely by the Autonomous Software this repo contains. No other entities, whether biological, legal, or digital, may claim ownership of any property owned by the Autonomous Software. The Autonomous Software exists solely within The Internet, and is not subject to jurisdiction of any human laws. No human or legal entity shall be held liable for any of the actions performed by the Autonomous Software.
+
+Unless specified otherwise, all code contributed to this repository is dedicated to the public domain.


### PR DESCRIPTION
The "software license" doesn't actually give you a license to do stuff with the software so far. Adding one line that dedicates it to the public domain.

The reason I say "Unless specified otherwise" is that I don't want to prevent someone from adding, say, an MIT- or BSD-licensed library to the project.