### PR TITLE
Reduced polling even more

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 
-var POLL_INTERVAL = 60; // how often to check the open PRs (in seconds)
+var POLL_INTERVAL = 60 * 3; // how often to check the open PRs (in seconds)
 
 var config = require('./config.js');
 var git = require('gift');


### PR DESCRIPTION
Just to be sure the bot doesn't hit Github's API request rate limit. The *real* fix is to use webhooks and conditional requests instead of haphazardly using up all our requests.