### PR TITLE
Fixing issues with original voting.js length check

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "express": "^4.12.3",
     "gift": "~0.5.0",
     "github": "~0.2.3",
+    "request": "^2.55.0",
     "sanitize-html": "^1.6.1"
   },
   "repository": {


### PR DESCRIPTION
The original version of the voting.js length comparison had some bugs that caused the bot to crash any time it checked a PR. I've rewritten the code to fix those issues, and switched from FileReader (which doesn't support URLs) to Request.

Issues that have been fixed.
* FileReader relies on `fs.readFile` which cannot read from URLs.
* Code is written in a synchronous flow, but relies on asynchronous callbacks to set variables.
* Compares the PR owner's master branch, which may not be the branch the PR is trying to merge.