### PR TITLE
Preemptively close the cached PR before merging it

### DIFF
--- a/voting.js
+++ b/voting.js
@@ -301,6 +301,9 @@ module.exports = function(config, gh, Twitter) {
         });
       }
 
+      // Flag the PR as closed pre-emptively to prevent multiple comments.
+      cachedPRs[pr.number].state = 'closed';
+
       gh.pullRequests.merge({
         user: config.user,
         repo: config.repo,


### PR DESCRIPTION
This should fix the bug with multiple comments on a successful merge. Same code already exists when we're closing/rejecting a PR