### PR TITLE
Adding some potential fixes to mergeability being detected incorrectly

### DIFF
--- a/lib/voting.js
+++ b/lib/voting.js
@@ -317,10 +317,19 @@ module.exports = function(config, gh, Twitter) {
 
     }, function(err, res) {
       if(err || !res) return cb(err);
-      if(!res.mergeable) {
+      if(res.mergeable === false) {
+        console.error('Attempted to merge PR #' + res.number +
+                      ' but it failed with a mergeable (' + res.mergeable +
+                      ') state of ' + res.mergeable_state);
         return closePR(couldntMergeWarning, pr, function() {
           cb(new Error('Could not merge PR because the author of the PR is a smeghead.'));
         });
+      } else if (res.mergeable === null) {
+        console.error('Attempted to merge PR #' + res.number +
+                      ' but it was postponed with a mergeable (' +
+                      res.mergeable + ') state of ' + res.mergeable_state);
+        // Try it again in 5 seconds if it failed with a "null" mergeable state.
+        return setTimeout(function () { mergePR(pr, cb); }, 5000);
       }
 
       // Flag the PR as closed pre-emptively to prevent multiple comments.


### PR DESCRIPTION
I've been checking out some of the PR API results, and it looks like this may be failing when mergeable is null. It should only fail if it is false (definitely not mergeable).

Between what I've noticed, and what the docs say, it seems like merging another branch moments before will cause the other PRs to do another merge-test. While this is happening, it seems to set the mergeability property to null. If it delays the merge by 5 seconds when detecting a null mergeability, it will hopefully give GitHub time to finish their test.