### PR TITLE
Reduce minimum time for voting to 15m (from 30m)

### DIFF
--- a/lib/voting.js
+++ b/lib/voting.js
@@ -8,7 +8,7 @@ var events = require('./events.js');
 var sentiment = require('sentiment');
 
 // voting settings
-var PERIOD = 30; // time for the vote to be open, in minutes
+var PERIOD = 15; // time for the vote to be open, in minutes
 var PERIOD_JITTER = 0.2; // fraction of period that is random
 var MIN_VOTES = 5; // minimum number of votes for a decision to be made
 var REQUIRED_SUPERMAJORITY = 0.65;


### PR DESCRIPTION
We're doing enough frequent changes that I feel the minimum voting period should be reduced. This still requires that five votes are made, but will help improve the functionality much easier.