### PR TITLE
Automatically reset vote counts when a PR is modified.

### DIFF
--- a/lib/voting.js
+++ b/lib/voting.js
@@ -32,12 +32,9 @@ var voteStartedComment = '#### :ballot_box_with_check: Voting procedure reminder
   'minutes (plus/minus **' + (PERIOD_JITTER*100) + '** percent, to avoid people timing their votes), ' +
   'and at least **'+MIN_VOTES+'** votes have been made.\n' +
   'A supermajority of **' + (REQUIRED_SUPERMAJORITY * 100) + '%** is required for the vote to pass.\n\n' +
-  '*NOTE: the PR will be closed if any new commits are added after:* ';
+  '*NOTE: the voting will be reset if any new commits are added after:* ';
 
-var modifiedWarning = '#### :warning: This PR has been modified and is now being closed.\n\n' +
-  'To prevent people from sneaking in changes after votes have been made, pull ' +
-  'requests can\'t be committed on after they have been opened. Feel free to ' +
-  'open a new PR for the proposed changes to start another round of voting.';
+var modifiedWarning = '#### :warning: This PR has been modified.\n\n' + voteStartedComment;
 
 var couldntMergeWarning = '#### :warning: Error: This PR could not be merged\n\n' +
   'The changes in this PR conflict with other changes, so we couldn\'t automatically merge it. ' +
@@ -120,9 +117,6 @@ module.exports = function(config, gh, Twitter) {
       postVoteStarted(pr);
     }
 
-    // TODO: instead of closing PRs that get changed, just post a warning that
-    //       votes have been reset, and only count votes that happen after the
-    //       last change
     assertNotModified(pr, function() {
       // if the age of the PR is >= the voting period, count the votes
       var age = Date.now() - new Date(pr.created_at).getTime();
@@ -183,18 +177,28 @@ module.exports = function(config, gh, Twitter) {
 
   // checks for a "vote started" comment posted by ourself
   // returns the comment if found
-  function getVoteStartedComment(pr, cb) {
-    for(var i = 0; i < pr.comments.length; i++) {
-      var postedByMe = pr.comments[i].user.login === config.user;
-      var isVoteStarted = pr.comments[i].body.indexOf(voteStartedComment) === 0;
-      if(postedByMe && isVoteStarted) {
-        // comment was found
-        return cb(null, pr.comments[i]);
+  function indexOfMostRecentBlessedHashComment(pr) {
+    for (var i = pr.comments.length; i > 0; --i) {
+      var theComment = pr.comments[i-1];
+      var postedByMe = theComment.user.login === config.user;
+
+      // TODO: isVoteStarted = theComment.body.endswithSHAhash();
+      var isVoteStarted = theComment.body.indexOf(voteStartedComment) >= 0;
+      if (postedByMe && isVoteStarted) {
+        return i-1;
       }
     }
+    return -1;
+  }
 
-    // comment wasn't found
-    return cb(null, null);
+  function getVoteStartedComment(pr, cb) {
+    var idx = indexOfMostRecentBlessedHashComment(pr);
+    if (idx >= 0) {
+      return cb(null, pr.comments[idx]);
+    } else {
+      // no blessed-hash comment was found
+      return cb(null, null);
+    }
   }
 
   // calls cb if the PR has not been committed to since the voting started,
@@ -206,8 +210,17 @@ module.exports = function(config, gh, Twitter) {
       if(comment) {
         var originalHead = comment.body.substr(comment.body.lastIndexOf(' ')+1);
         if(pr.head.sha !== originalHead) {
-          console.log('Posting a "modified PR" warning, and closing #' + pr.number);
-          return closePR(modifiedWarning, pr, noop);
+          console.log('Posting a "modified PR" warning and resetting votes on #' + pr.number);
+
+          gh.issues.createComment({
+            user: config.user,
+            repo: config.repo,
+            number: pr.number,
+            body: modifiedWarning + pr.head.sha
+          }, function(err, res) {
+            if(err) return console.error('error in postVoteStarted:', err);
+            return noop();
+          });
         }
       }
 
@@ -414,29 +427,28 @@ module.exports = function(config, gh, Twitter) {
    * Tally up the votes on a PR, and monitor which users are stargazers.
    */
   function tallyVotes(pr) {
-    var tally = pr.comments.reduce(function (result, comment) {
-      var user = comment.user.login,
-          body = comment.body;
+    var idx = indexOfMostRecentBlessedHashComment(pr);
+    var result = {
+      votes: {},
+      nonStarGazers: {}
+    };
 
-      // Don't check comments from the config user.
-      if(user === config.user) return result;
+    for (var i = idx+1; i < pr.comments.length; ++i) {
+      var comment = pr.comments[i];
+      var user = comment.user.login;
+      var body = comment.body;
+
       // People that don't star the repo cannot vote.
       if(!cachedStarGazers[user]) {
         result.nonStarGazers.push(user);
-        return result; 
       }
 
       // Skip people who vote both ways.
       var voteCast = calculateUserVote(body);
-      if (voteCast === null) { return result; }
-
-      result.votes[user] = voteCast;
-
-      return result;
-    }, {
-      votes: {},
-      nonStarGazers: [],
-    });
+      if (voteCast !== null) {
+        result.votes[user] = voteCast;
+      }
+    }
 
     // Add the PR author as a positive vote.
     tally.votes[pr.user.login] = true;


### PR DESCRIPTION
"Modifications" could be due to sneakiness, but could just be the
sensible way of resolving merge conflicts (e.g., you could notice
a merge conflict and rebase on top of `master`). This shouldn't
cause the whole PR to be wasted; it should simply reset the votes.

Only those votes posted since the most recent SHA-hash blessed by
the bot will be counted.  A SHA-hash is "blessed" if the bot has
posted it as the last word of a comment. (And only the bot; no other
users' comments can bless hashes.)

Notice that I'm removing a couple of unnecessary callback-style
interfaces. I'd eventually like to remove all of the callbacks
and replace them with straight-line code and/or event handlers;
but I refuse to do that until the
"merge conflict -> rebase -> PR auto-closed" pipeline is fixed.
Resetting votes instead of auto-closing PRs is the first step
in that direction.