### PR TITLE
Make information about time jitter more accurate

### DIFF
--- a/lib/voting.js
+++ b/lib/voting.js
@@ -29,7 +29,7 @@ var voteStartedComment = '#### :ballot_box_with_check: Voting procedure reminder
   'Comments containing both up- and down-votes are disregarded.\n' +
   'PR authors automatically count as a :+1: vote.\n\n' +
   'A decision will be made after this PR has been open for **'+PERIOD+'** ' +
-  'minutes (plus/minus **' + (PERIOD_JITTER*100) + '** percent, to avoid people timing their votes), ' +
+  'minutes (plus/minus **' + (PERIOD_JITTER*100/2) + '** percent, to avoid people timing their votes), ' +
   'and at least **'+MIN_VOTES+'** votes have been made.\n' +
   'A supermajority of **' + (REQUIRED_SUPERMAJORITY * 100) + '%** is required for the vote to pass.\n\n' +
   '*NOTE: the PR will be closed if any new commits are added after:* ';
@@ -51,7 +51,7 @@ var voteFailComment = ':-1: The vote failed. This PR will now be closed. Why don
 
 // We add a jitter to the PERIOD after the comment has been created, "to avoid people timing their votes".
 // More precisely, there is an incentive in the previous constant-period system to send in the vote at the last second,
-// because otherwise people can "react" to it by voting in the opposite direction (with our without sock-puppet accounts).
+// because otherwise people can "react" to it by voting in the opposite direction (without sock-puppet accounts).
 PERIOD = PERIOD * (1 + (Math.random() - 0.5) * PERIOD_JITTER);
 
 var voteEndComment = function(pass, yea, nay, nonStarGazers) {


### PR DESCRIPTION
(Math.random() - 0.5) * PERIOD_JITTER results with <-PERIOD_JITTER/2; PERIOD_JITTER/2) 

Therefore, the current information about PERIOD_JITTER was wrong, since with its value being 0.2 we get just plus/minus 10 percent of jitter, not 20.