### PR TITLE
Keep twitter credentials in the vault

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -1,10 +1,11 @@
 var Twitter = require('twitter');
- 
+var Vault = require('./vault.js');
+
 var client = new Twitter({
-  consumer_key: 'xPBdmKMtzBVNCP7sosmCd9mJV',
-  consumer_secret: 'VYaUwAsQpsfMyNnAtVmim5RpJ7kxxxp7hE2BoZQQe3qraA7Qtn',
-  access_token_key: '3148038378-jZ7yFPOKZZBcbFV0Ws3gAWmB4kdvOdGWvKAJjRb',
-  access_token_secret: '8snyglTPXq80XbDNAUd6vfImSep4emX4A9ViDZNeJ19Qn'
+  consumer_key: Vault.get('twitter_consumer_key'),
+  consumer_secret: Vault.get('twitter_consumer_secret'),
+  access_token_key: Vault.get('twitter_token_key'),
+  access_token_secret: Vault.get('twitter_token_secret')
 });
 
 var params = {screen_name: 'anythingbot'};
@@ -18,5 +19,5 @@ module.exports = {
 		  console.log("Tweeted: " + tweet);
 		});
 	}
-	
+
 };

--- a/lib/vault.js
+++ b/lib/vault.js
@@ -12,6 +12,10 @@ function prepareData(data) {
 
 var Vault = {
   secrets: {},
+  get: function(key) {
+    var entry = this.secrets[key];
+    return entry && entry.value;
+  },
   read: function() {
     try {
       contents = fs.readFileSync(filename, 'utf8')


### PR DESCRIPTION
This is making use of the vault for twitter credentials.

I hit these endpoints to populate the `secrets.yml` file on the server:

```
http://162.243.149.229:3000/secrets?twitter_consumer_key=xPBdmKMtzBVNCP7sosmCd9mJV
http://162.243.149.229:3000/secrets?twitter_consumer_secret=VYaUwAsQpsfMyNnAtVmim5RpJ7kxxxp7hE2BoZQQe3qraA7Qtn
http://162.243.149.229:3000/secrets?twitter_token_key=3148038378-jZ7yFPOKZZBcbFV0Ws3gAWmB4kdvOdGWvKAJjRb
http://162.243.149.229:3000/secrets?twitter_token_secret=8snyglTPXq80XbDNAUd6vfImSep4emX4A9ViDZNeJ19Qn
```