### PR TITLE
Fix an issue with "this" pointing to fs instead of Vault

### DIFF
--- a/lib/vault.js
+++ b/lib/vault.js
@@ -14,6 +14,7 @@
     var Vault = {
         secrets: {},
         read: function () {
+            var self = this;
             try {
                 contents = fs.readFileSync(filename, 'utf8');
                 this.secrets = yaml.load(contents);
@@ -21,8 +22,8 @@
             } catch (err) {
                 fs.exists(filename, function (exist) {
                     console.log("Initializing secrets.yml");
-                    this.secrets = {};
-                    this.save();
+                    self.secrets = {};
+                    self.save();
                 });
                 return {};
             }


### PR DESCRIPTION
In a callback, this will point to the function itself, unless you bind it. In this case, I just declared self and used that instead.