### PR TITLE
Add public config file

### DIFF
--- a/config.public.js
+++ b/config.public.js
@@ -1,0 +1,26 @@
+(function () {
+    'use strict';
+
+    module.exports = {
+        users: {
+            // 'foo': {
+            //     // typical hash and salt combination
+            //     'sha1': null,
+            //     'salt': null,
+
+            //     // other encryption methods may be added later
+            // }
+        },
+
+        vault: {
+            users: {
+                // 'foo': {
+                //     'keys': { // Access to keys containing object
+                //         'bar': {}, // object contains settings
+                //         'foobar': {},
+                //     }
+                // }
+            }
+        }
+    };
+}());


### PR DESCRIPTION
Where we add public secrets with votes!

### Details

This would allow us later to add public data like public passwords from users for authentication and authorization (so it says which users have access to what stuff).

The primary purpose would be for vaults, where we can add users democratically (so we see who has access to what).

They can add public passwords. Then they can mess up with private values where they are allowed with like tokens and other stuff they prefer to hide it from public. And all that, pretty securely as long everyone keeps an eye on this file ;-)

Please take care about this file as it will have super powers :-)

Note: this is part of commits related to #149