### PR TITLE
Auto-label pull requests 'Voting Underway', 'Merged' or 'Rejected'

### DIFF
--- a/lib/integrations/github_labels.js
+++ b/lib/integrations/github_labels.js
@@ -88,19 +88,16 @@
                             getStatusLabel(VOTING_MERGED),
                             getStatusLabel(VOTING_REJECTED)
                         ], prLabels);
-
                     } else if (label.name === VOTING_REJECTED) {
                         prLabels = removeUnwantedLabels([
                             getStatusLabel(VOTING_MERGED),
                             getStatusLabel(VOTING_UNDERWAY)
                         ], prLabels);
-
                     } else if (label.name === VOTING_MERGED) {
                         prLabels = removeUnwantedLabels([
                             getStatusLabel(VOTING_REJECTED),
                             getStatusLabel(VOTING_UNDERWAY)
                         ], prLabels);
-
                     }
 
                     // Add the status label that we want


### PR DESCRIPTION
This relies heavily on webhooks, currently.

As a first-pass, this will work only on future pull requests.

The next logical steps stemming from this PR would be:
- Refactor to make the add / remove labels code simpler and more maintainable
- Add in a 'cleanup' job:
 - Get all pull requests that are not labelled, or are labelled as 'Voting Underway'
 - Determine the true status of the pull request
 - Fix the label to match the status of the pull request