### PR TITLE
Mock Twitter requests for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The bot has a built-in webserver for monitoring its current state.
 1. Fork this repo.
 1. Get yourself an OAuth token for github at https://github.com/settings/tokens/new. (TODO what scopes are required?)
 1. Copy config.template.js -> config.js and modify accordingly.
+1. Disable any items in the mocks section that you would like to function normally.
 
 ```javascript
 $ cp config.template.js config.js

--- a/README.md
+++ b/README.md
@@ -48,12 +48,18 @@ $ cat config.js
     'use strict';
 
     module.exports = {
+        webserver: {
+            port: 3000
+        },
         user: "YOUR_GITHUB_USERNAME",
         repo: "botwillacceptanything",
         githubAuth: {
             type: "oauth",
             token: "YOUR_OAUTH_TOKEN"
-        }
+        },
+        mocks: {
+            twitter: true,
+        },
     };
 }());
 

--- a/config.template.js
+++ b/config.template.js
@@ -12,6 +12,9 @@
             type: "oauth",
             token: "YOUR_OAUTH_TOKEN",
             webhookSecret: 'SECRET'
-        }
+        },
+        mocks: {
+            twitter: true,
+        },
     };
 }());

--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@
     var voting = require('./lib/voting.js');
     var webserver = require('./lib/webserver.js')(config);
     var talk = require('./lib/talk.js')(config, gh);
+    var mocks = require('./tests/mocks/index.js');
     var integrations = require('./lib/integrations/index.js');
     var Logger = require('./lib/logger');
 
@@ -81,10 +82,12 @@
         });
     }
 
-    integrations().then(main, function (err) {
-      Logger.error(err);
-      Logger.error(err.stack);
-    });
+    mocks()
+      .then(integrations)
+      .then(main, function (err) {
+        Logger.error(err);
+        Logger.error(err.stack);
+      });
 
     process.on('uncaughtException', function (err) {
         console.error('UNCAUGHT ERROR: ' + err + '\n' + err.stack);

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lodash": "^3.6.0",
     "morgan": "^1.5.2",
     "mustache": "2.0.0",
+    "nock": "^1.6.0",
     "request": "^2.55.0",
     "sanitize-html": "^1.6.1",
     "sentiment": "^1.0.2",

--- a/tests/mocks/index.js
+++ b/tests/mocks/index.js
@@ -1,0 +1,45 @@
+(function () {
+  'use strict';
+
+  var define = require('amdefine')(module);
+
+  var deps = [
+    'deferred',
+    'fs',
+    'path',
+    'nock',
+
+    '../../config.js',
+    '../../lib/logger',
+  ];
+
+  define(deps, function (deferred, fs, path, nock, config, Logger) {
+    module.exports = function () {
+      nock.enableNetConnect();
+
+      if (typeof config.mocks === 'undefined') { return deferred(1); }
+
+      var d = deferred(1);
+
+      Logger.log('Initializing mocks.');
+
+      Object.keys(config.mocks)
+        .filter(function (mock) {
+          return config.mocks[mock] == true;
+        })
+        .map(function (mock) {
+          var filePath = path.join(__dirname, mock + '.js');
+          Logger.info('Loading ' + filePath);
+          d.then(function () { require(filePath)(); });
+        });
+
+      d.then(d.resolve,
+        function (err) {
+          Logger.error(err);
+          Logger.error(err.stack);
+        });
+
+      return d;
+    }
+  });
+}());

--- a/tests/mocks/twitter.js
+++ b/tests/mocks/twitter.js
@@ -1,0 +1,20 @@
+(function () {
+  'use strict';
+
+  var define = require('amdefine')(module);
+
+  var deps = [
+    'nock',
+  ];
+
+  define(deps, function (nock) {
+    module.exports = function () {
+      nock('https://api.twitter.com')
+        .post('/1.1/statuses/update.json')
+        .reply(200, {
+          id_str: '123456789012345678',
+          created_at: "Wed Sep 05 00:37:15 +0000 2012",
+        });
+    }
+  });
+}());

--- a/tests/mocks/twitter.js
+++ b/tests/mocks/twitter.js
@@ -10,6 +10,7 @@
   define(deps, function (nock) {
     module.exports = function () {
       nock('https://api.twitter.com')
+        .persist()
         .post('/1.1/statuses/update.json')
         .reply(200, {
           id_str: '123456789012345678',


### PR DESCRIPTION
Integrate a basic system for handling HTTP requests, that we can begin writing tests that don't tweet to @anythingbot