### PR TITLE
Fix issue with data/author.txt not regenerating after a merge

### DIFF
--- a/authors.sh
+++ b/authors.sh
@@ -1,3 +1,3 @@
 #! /usr/bin/env bash
 
-git shortlog -s -n < /dev/tty | tee data/authors.txt
+git log | git shortlog -s -n | tee data/authors.txt


### PR DESCRIPTION
git shortlog expects a tty, or a log to be passed into it. Piping `git log` into `git shortlog` does the trick, and now `data/authors.txt` will reliably regenerate after a merge.