### PR TITLE
Cleaned up the commits webpage

### DIFF
--- a/data/views/commits.hbs
+++ b/data/views/commits.hbs
@@ -15,9 +15,8 @@
 	</script>
 <br />
 <h1>Recent Commits</h1>
-"<p>
+<p>
     {{#each messages}}
-        {{this.author.name}} added {{this.id}} - {{this.message}}<br />
-    {{/each}}
+        <a href="https://github.com/{{config.user}}/{{config.repo}}/commit/{{this.id}}">{{this.author.name}} - {{this.message}}</a><br />    {{/each}}
 </p>
 </center>

--- a/data/views/commits.hbs
+++ b/data/views/commits.hbs
@@ -17,6 +17,6 @@
 <h1>Recent Commits</h1>
 <p>
     {{#each messages}}
-        <a href="https://github.com/{{config.user}}/{{config.repo}}/commit/{{this.id}}">{{this.author.name}} - {{this.message}}</a><br />    {{/each}}
+        <a href="https://github.com/{{../config.user}}/{{../config.repo}}/commit/{{this.id}}">{{this.author.name}} - {{this.message}}</a><br />    {{/each}}
 </p>
 </center>


### PR DESCRIPTION
Myself and @SpenserJ have cleaned up the commits page by instead of showing the full commit ID, we just linked the URL to it