### PR TITLE
Don't skip votes from the bot

### DIFF
--- a/lib/voting.js
+++ b/lib/voting.js
@@ -401,8 +401,6 @@
             var user = comment.user.login,
                 body = comment.body;
 
-            // Don't check comments from the config user.
-            if (user === config.user) { return result; }
             // People that don't star the repo cannot vote.
             if (!cachedStarGazers[user]) {
                 result.nonStarGazers.push(user);
@@ -425,14 +423,6 @@
 
         // Add the PR author as a positive vote.
         tally.votes[pr.user.login] = true;
-
-        // determine whether I like this PR or not (or don't care)
-        var score = sentiment(pr.title + ' ' + pr.body).score;
-        if (score > 1) {
-            tally.votes[config.user] = true;
-        } else if (score < -1) {
-            tally.votes[config.user] = false;
-        }
 
         var tallySpread = Object.keys(tally.votes).reduce(function (result, user) {
             // Increment the positive/negative counters.


### PR DESCRIPTION
Now that we ignore votes with both :-1: and :+1: we can safely take bot's votes into account, which allows us to simplify the voting code itself (it now can analyze the sentiment in just once place instead of two).