### PR TITLE
Developing basic system for an environment-based configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # config
 config.js
+configs/custom.js
 
 # Logs
 logs

--- a/config.loader.js
+++ b/config.loader.js
@@ -1,0 +1,52 @@
+(function () {
+  'use strict';
+
+  var define = require('amdefine')(module);
+  var fs = require('fs');
+  var fse = require('fs-extra');
+
+  var deps = [
+    './configs/custom.js',
+    'lodash',
+    './config.template.js',
+  ];
+
+  var err;
+
+  var exists = fs.existsSync('./configs/custom.js');
+  if (exists === true) { return prepareConfig(); }
+
+  err = fs.renameSync('./config.js', './configs/custom.js');
+  // If an error occurred, load the original config.js.
+  if (err) {
+    console.error(err);
+    console.error(err.stack);
+    deps[0] = './config.js';
+    return prepareConfig();
+  }
+
+  err = fse.copySync(__filename, './config.js');
+  if (err) {
+    console.error(err);
+    console.error(err.stack);
+  }
+  prepareConfig();
+
+  function prepareConfig() {
+    var exists = fs.existsSync('./configs/' + process.env.BUILD_ENVIRONMENT + '.js');
+
+    console.log(process.env.BUILD_ENVIRONMENT);
+    if (exists === true) {
+      deps.push('./configs/' + process.env.BUILD_ENVIRONMENT + '.js');
+    }
+    mergeConfig();
+  }
+
+  function mergeConfig() {
+    define(deps, function (config, _, template, env) {
+      if (typeof env === 'undefined') { env = {}; }
+      _.merge(template, config, env);
+      module.exports = template;
+    });
+  }
+}());

--- a/configs/development.js
+++ b/configs/development.js
@@ -1,0 +1,5 @@
+module.exports = {
+  mocks: {
+    twitter: true,
+  },
+};

--- a/configs/test.js
+++ b/configs/test.js
@@ -1,0 +1,5 @@
+module.exports = {
+  mocks: {
+    twitter: true,
+  },
+};

--- a/main.js
+++ b/main.js
@@ -1,5 +1,10 @@
 (function() {
-    var config = require('./config.js');
+    // If no env is set yet, set it to development.
+    if (typeof process.env.BUILD_ENVIRONMENT === 'undefined') {
+        process.env.BUILD_ENVIRONMENT = 'development';
+    }
+
+    var config = require('./config.loader.js');
     var git = require('gift');
     var spawn = require('child_process').spawn;
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "errorhandler": "^1.3.5",
     "express": "^4.12.3",
     "express-handlebars": "^2.0.0",
+    "fs-extra": "^0.18.1",
     "gift": "~0.6.0",
     "github": "~0.2.3",
     "intercept-stdout": "0.0.3",


### PR DESCRIPTION
This is a two-part merge request, to ensure we don't break anyone's `config.js` file. The first step is a `config.loader.js`, that will move existing `config.js` files to `configs/custom.js`, and then copy itself into `config.js` to ensure all other configs load properly.
After this is merged, and enough time has passed, we can write a second PR that will clean up the code that is no longer needed, and set up `config.js` as our primary config loader.

The goal of this change is to allow us to load configs specific to the environment (`process.env.BUILD_ENVIRONMENT`), so that tests are properly configured, and development systems don't spam the twitter account or IRC channel.

If you have a problem with the implementation, please explain why, as this will be a substantial improvement to the capabilities of the bot, and I'd rather go through multiple revisions to make sure we hit all of our targets, that have it downvoted without something we can improve.