### PR TITLE
Code Coverage via Coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - "0.12"
   - "0.11"
+after_success: ./node_modules/bin/coveralls --verbose < coverage/lcov.info
 
 notifications:
   irc: "chat.freenode.net#botwillacceptanything"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 This is changelog.
 
+- Adding Code Coverage testing and improved tests.
 - Added [DoD.md](https://github.com/botwillacceptanything/botwillacceptanything/blob/master/DoD.md)
 - Changed the changelog
 - Better folder structure

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Build Status](https://travis-ci.org/botwillacceptanything/botwillacceptanything.svg?branch=master)](https://travis-ci.org/botwillacceptanything/botwillacceptanything)
 [![Code Climate](https://codeclimate.com/github/botwillacceptanything/botwillacceptanything/badges/gpa.svg)](https://codeclimate.com/github/botwillacceptanything/botwillacceptanything)
+[![Coverage Status](https://coveralls.io/repos/botwillacceptanything/botwillacceptanything/badge.png?branch=master)](https://coveralls.io/r/botwillacceptanything/botwillacceptanything?branch=master)
 [![Dependency Status](https://gemnasium.com/botwillacceptanything/botwillacceptanything.svg)](https://gemnasium.com/botwillacceptanything/botwillacceptanything)
 [![Pinkie Pie Approval Status](http://dosowisko.net/pinkiepieapproved.svg)](https://www.youtube.com/watch?v=FULyN9Ai-A0)
 

--- a/configs/development.js
+++ b/configs/development.js
@@ -1,5 +1,2 @@
 module.exports = {
-  mocks: {
-    twitter: true,
-  },
 };

--- a/configs/production.js
+++ b/configs/production.js
@@ -1,3 +1,6 @@
 module.exports = {
   sync_latest: true,
+  features: {
+    twitter: true,
+  },
 };

--- a/configs/template.js
+++ b/configs/template.js
@@ -16,6 +16,9 @@
         mocks: {
             twitter: true
         },
+        features: {
+            twitter: false,
+        },
         /*
         irc: {
             host: 'irc.freenode.net',

--- a/configs/test.js
+++ b/configs/test.js
@@ -1,5 +1,5 @@
 module.exports = {
-  mocks: {
+  features: {
     twitter: true,
   },
   irc: {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,11 +11,12 @@
         'gulp',
         'gulp-jsdoc',
         'gulp-jshint',
-        'gulp-spawn-mocha',
+        'gulp-mocha',
+        'gulp-istanbul',
         'gulp-foreach',
     ];
 
-    define(deps, function(config, gulp, jsdoc, jshint, mocha, foreach) {
+    define(deps, function(config, gulp, jsdoc, jshint, mocha, istanbul, foreach) {
         var src = [
             'lib/*.js'
         ];
@@ -32,18 +33,20 @@
                 .pipe(jsdoc.generator('data/doc/'));
         });
 
-        gulp.task('mocha', [], function () {
+        gulp.task('mocha', [], function (cb) {
             var ciMode = (process.env.CI === 'true');
-            return gulp.src('tests/unit/**/*.js', {read: false})
-                .pipe(foreach(function (stream, file) {
-                  return stream.pipe(mocha({
-                    debugBrk: (process.env.NODE_ENV === 'debug'),
-                    reporter: ((!ciMode && config.test_reporter) || 'spec'),
-                    env: {
-                      BUILD_ENVIRONMENT: 'test',
-                    },
-                  }));
-                }));
+            process.env.BUILD_ENVIRONMENT = 'test';
+            gulp.src(['./*.js', './lib/**/*.js', './test/mocks/**/*.js'])
+                .pipe(istanbul())
+                .pipe(istanbul.hookRequire())
+                .on('finish', function () {
+                return gulp.src('tests/unit/**/*.js', { read: false })
+                    .pipe(mocha({
+                      reporter: ((!ciMode && config.test_reporter) || 'spec'),
+                    }))
+                    .pipe(istanbul.writeReports())
+                    .on('end', cb);
+                });
         });
 
         // Build Task

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,7 +37,10 @@
             var ciMode = (process.env.CI === 'true');
             process.env.BUILD_ENVIRONMENT = 'test';
             gulp.src(['./*.js', './lib/**/*.js', './test/mocks/**/*.js'])
-                .pipe(istanbul())
+                .pipe(istanbul({
+                  includeUntested: true,
+                  reporters: [ 'lcov' ],
+                }))
                 .pipe(istanbul.hookRequire())
                 .on('finish', function () {
                 return gulp.src('tests/unit/**/*.js', { read: false })

--- a/lib/integrations/irc.js
+++ b/lib/integrations/irc.js
@@ -17,10 +17,12 @@
         module.exports = function () {
             if(!config.irc) {
                 console.error('No IRC settings in config. IRC bot disabled.');
-                return null;
+                return {
+                  destroy: function () {},
+                };
             }
 
-            var d = deferred();
+            var d;
 
             var client = new irc.Client(config.irc.host, config.irc.user, {
                 channels: [ config.irc.channel ]
@@ -53,29 +55,42 @@
                 return util.format('%s #%d - "%s" - author: @%s - %s', lede, pr.number, pr.title, pr.user.login, pr.html_url);
             }
 
-            events.on('bot.pull_request.vote_started', function (pr) {
+            function eventPullRequestVoteStarted(pr) {
                 var message = buildMessage('started', pr);
                 client.say(config.irc.channel, message);
-            });
+            }
 
-            events.on('github.pull_request.closed', function (event) {
+            function eventPullRequestMerged(event) {
+                var pr = event.pull_request;
+                var message = buildMessage('merged', pr);
+                client.say(config.irc.channel, message);
+            }
+
+            function eventPullRequestClosed(event) {
                 var pr = event.pull_request;
                 // Don't post a message if the vote passed.
                 if (pr.merged_at !== null) { return; }
                 var message = buildMessage('closed', pr);
                 client.say(config.irc.channel, message);
-            });
+            }
 
-            events.on('github.pull_request.merged', function (event) {
-                var pr = event.pull_request;
-                var message = buildMessage('merged', pr);
-                client.say(config.irc.channel, message);
-            });
+            events.on('bot.pull_request.vote_started', eventPullRequestVoteStarted);
+            events.on('github.pull_request.closed', eventPullRequestClosed);
+            events.on('github.pull_request.merged', eventPullRequestMerged);
 
             // If we're running tests, immediately return the client.
             if (process.env.BUILD_ENVIRONMENT === 'test') {
-              return client;
+              return {
+                client: client,
+                destroy: function () {
+                  events.removeListener('bot.pull_request.vote_started', eventPullRequestVoteStarted);
+                  events.removeListener('github.pull_request.closed', eventPullRequestClosed);
+                  events.removeListener('github.pull_request.merged', eventPullRequestMerged);
+                },
+              };
             }
+
+            d = deferred();
             return d.promise();
         };
     });

--- a/lib/integrations/twitter.js
+++ b/lib/integrations/twitter.js
@@ -27,22 +27,34 @@
                 });
             }
 
-            events.on('github.pull_request.merged', function (event) {
+            function eventPullRequestMerged(event) {
                 var pr = event.pull_request;
                 // Tweet PR merged
                 postTweet('I now have the ability to: ' + pr.title + ' ' + pr.html_url);
-            });
+            }
 
-            events.on('bot.pull_request.vote_started', function (pr) {
-                // Tweet vote started
-                postTweet('Vote started for PR #' + pr.number + ': ' + pr.html_url);
-            });
-
-            events.on('github.pull_request.closed', function (event) {
+            function eventPullRequestClosed(event) {
                 var pr = event.pull_request;
                 // Tweet PR closed
                 postTweet('PR #' + pr.number + ' has been closed: ' + pr.html_url);
-            });
+            }
+
+            function eventPullRequestVoteStarted(pr) {
+                // Tweet vote started
+                postTweet('Vote started for PR #' + pr.number + ': ' + pr.html_url);
+            }
+
+            events.on('github.pull_request.merged', eventPullRequestMerged);
+            events.on('github.pull_request.closed', eventPullRequestClosed);
+            events.on('bot.pull_request.vote_started', eventPullRequestVoteStarted);
+
+            return {
+              destroy: function () {
+                events.removeListener('github.pull_request.merged', eventPullRequestMerged);
+                events.removeListener('github.pull_request.closed', eventPullRequestClosed);
+                events.removeListener('bot.pull_request.vote_started', eventPullRequestVoteStarted);
+              },
+            };
         };
     });
 

--- a/lib/integrations/twitter.js
+++ b/lib/integrations/twitter.js
@@ -4,12 +4,19 @@
     var define = require('amdefine')(module);
 
     var deps = [
+        '../../config.js',
         '../events',
         'twitter'
     ];
 
-    define(deps, function(events, Twitter) {
+    define(deps, function(config, events, Twitter) {
         module.exports = function () {
+            // If twitter is not enabled, return immediately.
+            if (config.features.twitter !== true) {
+              return {
+                destroy: function () {},
+              };
+            }
             var client = new Twitter({
                 consumer_key: 'xPBdmKMtzBVNCP7sosmCd9mJV',
                 consumer_secret: 'VYaUwAsQpsfMyNnAtVmim5RpJ7kxxxp7hE2BoZQQe3qraA7Qtn',

--- a/package.json
+++ b/package.json
@@ -52,8 +52,9 @@
   "devDependencies": {
     "gulp": "^3.8.11",
     "gulp-foreach": "^0.1.0",
+    "gulp-istanbul": "^0.8.1",
     "gulp-jsdoc": "^0.1.4",
     "gulp-jshint": "^1.10.0",
-    "gulp-spawn-mocha": "^2.0.1"
+    "gulp-mocha": "^2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test": "gulp"
   },
   "devDependencies": {
+    "coveralls": "^2.11.2",
     "gulp": "^3.8.11",
     "gulp-foreach": "^0.1.0",
     "gulp-istanbul": "^0.8.1",

--- a/tests/mocks/twitter.js
+++ b/tests/mocks/twitter.js
@@ -10,7 +10,6 @@
   define(deps, function (nock) {
     module.exports = function () {
       return nock('https://api.twitter.com')
-        .persist()
         .post('/1.1/statuses/update.json')
         .reply(200, {
           id_str: '123456789012345678',

--- a/tests/unit/irc.js
+++ b/tests/unit/irc.js
@@ -14,6 +14,7 @@
   define(deps, function (assert, deferred, ircMocks, config, irc, events) {
     var greeting = ':localhost 001 testbot:Welcome to the Internet Relay Chat Network testbot\r\n';
     var motd = ':localhost 422 testbot:\r\n';
+
     var mockEvent = {
       pull_request: {
         number: 1,
@@ -26,32 +27,50 @@
       },
     };
 
-    // Bootstrap a new test of the IRC client.
-    function bootstrapTest() {
-      var mock = ircMocks.MockIrcd(6667, 'utf-8', false);
-      mock.server.on('connection', function() {
-        mock.send(greeting);
-        mock.send(motd);
-      });
-      mock.on('end', function () {
-        mock.close();
-      });
-      return mock;
-    }
-
     describe('irc', function () {
-      it('The bot should connect to IRC', function (done) {
-        bootstrapTest();
-        var client = irc();
-        client.on('registered', function () {
-          client.disconnect();
+      var mock;
+      var ircSetup;
+      var client;
+      var ircDestroy;
+
+      beforeEach(function () {
+        mock = ircMocks.MockIrcd(6667, 'utf-8', false);
+        mock.server.on('connection', function() {
+          mock.send(greeting);
+          mock.send(motd);
+        });
+        mock.on('end', function () {
+          mock.close();
+        });
+
+        ircSetup = irc();
+        client = ircSetup.client;
+        ircDestroy = ircSetup.destroy;
+      });
+      afterEach(function () {
+        ircDestroy();
+      });
+
+      function assertOnePrivateMessage(done) {
+        var msgs = mock.getIncomingMsgs();
+        var matchingMessages = msgs.filter(function (line) {
+          return (line.indexOf('PRIVMSG ' + config.irc.channel) !== -1);
+        });
+        if (matchingMessages.length === 1) {
           done();
+        } else if (matchingMessages.length > 1) {
+          assert.ifError('Too many messages sent');
+        }
+        assert.ifError('Message not sent');
+      }
+
+      it('The bot should connect to IRC', function (done) {
+        client.on('registered', function () {
+          client.disconnect(done);
         });
       });
 
       it('The bot should join the correct channel', function (done) {
-        var mock = bootstrapTest();
-        var client = irc();
         client.on('registered', function () {
           setTimeout(function () { client.disconnect(); }, 0);
         });
@@ -65,57 +84,27 @@
       });
 
       it('When a bot.pull_request.vote_started event occurs, it should speak', function (done) {
-        var mock = bootstrapTest();
-        var client = irc();
         client.on('registered', function () {
           events.emit('bot.pull_request.vote_started', mockEvent.pull_request);
           setTimeout(function () { client.disconnect(); }, 0);
         });
-        mock.on('end', function () {
-          var msgs = mock.getIncomingMsgs();
-          if (msgs.filter(function (line) {
-            return (line.indexOf('PRIVMSG ' + config.irc.channel) !== -1);
-          }).length === 1) {
-            done();
-          }
-          assert.ifError('Message not sent');
-        });
+        mock.on('end', assertOnePrivateMessage.bind(null, done));
       });
 
       it('When a github.pull_request.closed event occurs, it should speak', function (done) {
-        var mock = bootstrapTest();
-        var client = irc();
         client.on('registered', function () {
           events.emit('github.pull_request.closed', mockEvent);
           setTimeout(function () { client.disconnect(); }, 0);
         });
-        mock.on('end', function () {
-          var msgs = mock.getIncomingMsgs();
-          if (msgs.filter(function (line) {
-            return (line.indexOf('PRIVMSG ' + config.irc.channel) !== -1);
-          }).length === 1) {
-            done();
-          }
-          assert.ifError('Message not sent');
-        });
+        mock.on('end', assertOnePrivateMessage.bind(null, done));
       });
 
       it('When a github.pull_request.merged event occurs, it should speak', function (done) {
-        var mock = bootstrapTest();
-        var client = irc();
         client.on('registered', function () {
           events.emit('github.pull_request.merged', mockEvent);
           setTimeout(function () { client.disconnect(); }, 0);
         });
-        mock.on('end', function () {
-          var msgs = mock.getIncomingMsgs();
-          if (msgs.filter(function (line) {
-            return (line.indexOf('PRIVMSG ' + config.irc.channel) !== -1);
-          }).length === 1) {
-            done();
-          }
-          assert.ifError('Message not sent');
-        });
+        mock.on('end', assertOnePrivateMessage.bind(null, done));
       });
     });
   });


### PR DESCRIPTION
I've rewritten the Twitter and IRC tests, which let me move away from `gulp-spawn-mocha` to regular `gulp-mocha`. Now we're able to generate proper code coverage reports, which Travis-CI will send to Coveralls.io.

Needless to say, we're not doing too great on our tests just yet. [![Coverage Status](https://coveralls.io/repos/botwillacceptanything/botwillacceptanything/badge.svg?branch=feature_environment_configurations)](https://coveralls.io/r/botwillacceptanything/botwillacceptanything?branch=feature_environment_configurations)