### PR TITLE
Limit the files that are auto-loaded from integrations folder

### DIFF
--- a/lib/integrations/index.js
+++ b/lib/integrations/index.js
@@ -21,13 +21,13 @@
             var readdir = deferred.promisify(fs.readdir);
             readdir(__dirname)
                 .map(function (file) {
-                    if(file == 'index.js') {
-                        return;
+                    // Only load .js files in the current directory, do not recurse
+                    // sub-directories, do not include index.js
+                    if (file.match(/^.+\.js$/g) && file !== 'index.js') {
+                        var filePath = path.join(__dirname, file);
+                        Logger.info('Loading ' + filePath);
+                        return require(filePath)();
                     }
-
-                    var filePath = path.join(__dirname, file);
-                    Logger.info('Loading ' + filePath);
-                    return require(filePath)();
                 })
                 .then(d.resolve, function (err) {
                     Logger.error(err);


### PR DESCRIPTION
- Only loads javascript **.js** files currently.
- Only loads from the root of the integrations folder, does not recurse sub-directories. This is a good thing.
- Does not load **index.js**