### PR TITLE
Remove useless GET variable

### DIFF
--- a/data/views/layouts/main.hbs
+++ b/data/views/layouts/main.hbs
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <link rel="icon" type="image/ico" href="/favicon.ico?raw=true">
+        <link rel="icon" type="image/ico" href="/favicon.ico">
         <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
         <title>Bot Will Accept Anything</title>
         <meta name="author" content="GitHub Commitors">


### PR DESCRIPTION
Remove useless GET variable from favicon URL.

I spent a few hours trying to find out where ?raw=true was used in our stack, turns out: it isns't.

I feel this is a holdover from a GitHub URL that required ?raw=true

Leaving this in is a problem because: if it is there, its there for a reason. Future developers will be hesitant to remove it because it might mean something, right? But it doesn't, so lets get rid of it.