### PR TITLE
Non-stargazers make monkey votes.

### DIFF
--- a/data/templates/voting/nonStarGazerVote.md
+++ b/data/templates/voting/nonStarGazerVote.md
@@ -1,0 +1,7 @@
+{{body}}
+
+> :monkey: @{{user}}, we can't count your vote because you must :star:star the repository.
+> If you want your vote to count
+> - :star:star the repository
+> - Wait for **{{stargazerRefreshInterval}}** minute(s)
+> - Remove this message (including the :monkey:`:monkey:`), or post a new vote.

--- a/data/templates/voting/voteStarted.md
+++ b/data/templates/voting/voteStarted.md
@@ -1,11 +1,12 @@
 #### :ballot_box_with_check: Voting procedure reminder:
-To cast a vote, post a comment containing `:+1:` (:+1:), or `:-1:` (:-1:).
+To cast a vote, post a comment containing :+1:`:+1:`, or :-1:`:-1:`.
 Remember, you **must :star:star this repo for your vote to count.**
 
 All comments within this discussion are searched for votes, regardless of the time of posting.
 You can cast as many votes as you want, but only the last one will be counted.
 (You may consider editing your comment instead of adding a new one.)
-Comments containing both up- and down-votes are disregarded.
+Comments containing both :+1:up- and :-1:down-votes are disregarded.
+Comments containing monkeys are disregarded. :monkey: :monkey_face: :see_no_evil: :hear_no_evil: :speak_no_evil:
 PR authors automatically count as a :+1: vote.
 
 A decision will be made after this PR has been open for **{{period}}** minutes (plus/minus **{{jitter}}** percent, to avoid people timing their votes), and at least **{{min_votes}}** votes have been made.

--- a/ideas.md
+++ b/ideas.md
@@ -11,5 +11,5 @@
  - [x] When tweeting, shorten links and include PR title.
  - [x] IRC Bot to post live updates to the IRC chatroom.
  - [x] Write Definition of Done file that all PRs should try to meet
- - [ ] When non-stargazers vote, poke them with a comment immediately.
+ - [x] When non-stargazers vote, poke them with a comment immediately.
  - [ ] IRC Bot updates the title of the IRC chatroom with the GitHub vote status.

--- a/lib/voting.js
+++ b/lib/voting.js
@@ -15,6 +15,9 @@
     var REQUIRED_SUPERMAJORITY = 0.65;
     var MINUTE = 60 * 1000; // (one minute in ms)
     var POLL_INTERVAL = MINUTE * 3; // how often to check the open PRs (in seconds)
+    var VOTE_POSITIVE = ':+1:';
+    var VOTE_NEGATIVE = ':-1:';
+    var VOTE_MONKEY = [':monkey:', ':monkey_face:', ':hear_no_evil:',':see_no_evil:',':speak_no_evil:'];
 
     var decideVoteResult = function (yeas, nays) {
         // vote passes if yeas > nays
@@ -59,6 +62,15 @@
             });
         }
         return resp;
+    }
+
+    var nonStarGazerComment = function (voteCast, body, user) {
+        return (template.render('voting/nonStarGazerVote.md', {
+            user: user,
+            body: body,
+            vote: voteCast,
+            stargazerRefreshInterval: (POLL_INTERVAL / MINUTE) // Use readable interval value
+        }));
     };
 
     var votesPerPR = {};
@@ -145,7 +157,7 @@
                         user: config.user,
                         repo: config.repo,
                         number: pr.number,
-                        body: ':+1:'
+                        body: VOTE_POSITIVE
                     });
                 } else if (score < -1) {
                     // Ugh, this PR sucks, boooo!
@@ -153,7 +165,7 @@
                         user: config.user,
                         repo: config.repo,
                         number: pr.number,
-                        body: ':-1:'
+                        body: VOTE_NEGATIVE
                     });
                 } // otherwise it's meh, so I don't care
             });
@@ -399,23 +411,40 @@
     function tallyVotes(pr) {
         var tally = pr.comments.reduce(function (result, comment) {
             var user = comment.user.login,
-                body = comment.body;
+                body = comment.body,
+                voteCast = calculateUserVote(body);
 
             // People that don't star the repo cannot vote.
             if (!cachedStarGazers[user]) {
                 if (result.nonStarGazers.indexOf(user) === -1) {
                     result.nonStarGazers.push(user);
                 }
+
+                if (voteCast !== VOTE_MONKEY && voteCast !== null) {
+                    // This comment has not yet been marked as a monkey, but should be.
+                    // The user is not a stargazer, but has made a vote-style comment.
+                    // Edit the comment with a monkey warning appended to the end.
+                    gh.issues.editComment({
+                        user: config.user,
+                        repo: config.repo,
+                        id: comment.id,
+                        body: nonStarGazerComment(voteCast, body, user)
+                    }, noop);
+                }
                 return result;
             }
 
-            // Skip people who vote both ways.
-            var voteCast = calculateUserVote(body);
-            if (voteCast === null) {
-                return result;
+            // Only record votes that are explicitly
+            // positive, or negative.
+            // Monkeys and votes that go both ways
+            // do not record a result.
+            if (voteCast === VOTE_POSITIVE) {
+                result.votes[user] = true;
             }
 
-            result.votes[user] = voteCast;
+            if (voteCast === VOTE_NEGATIVE) {
+                result.votes[user] = false;
+            }
 
             return result;
         }, {
@@ -425,7 +454,7 @@
 
         // Add the PR author as a positive vote by default.
         if (!(pr.user.login in tally.votes)) {
-            tally.votes[pr.user.login] = true;
+            tally.votes[pr.user.login] = VOTE_POSITIVE;
         }
 
         var tallySpread = Object.keys(tally.votes).reduce(function (result, user) {
@@ -456,12 +485,37 @@
         return tally;
     }
 
+    // Returns true if the text contains a positive vote
+    function isPositive (text) {
+        return (text.indexOf(VOTE_POSITIVE) !== -1);
+    }
+
+    // Returns true if the text contains a negative vote
+    function isNegative (text) {
+        return (text.indexOf(VOTE_NEGATIVE) !== -1);
+    }
+
+    // Returns true if the text is a monkey vote.
+    function isMonkey (text) {
+        // VOTE_MONKEY is an array of monkey vote keys.
+        // If any of those keys appears in the text, the
+        // vote is a monkey.
+        return VOTE_MONKEY.some(function (monkey) {
+            return (text.indexOf(monkey) !== -1);
+        });
+    }
+
     /**
      * Check the text of a comment, and determine what vote was cast.
      */
     function calculateUserVote(text) {
-        var positive = (text.indexOf(':+1:') !== -1),
-            negative = (text.indexOf(':-1:') !== -1);
+        var positive = isPositive(text),
+            negative = isNegative(text),
+            monkey = isMonkey(text);
+
+        if (monkey) {
+            return VOTE_MONKEY;
+        }
 
         // If the user has voted positive and negative, or hasn't voted, ignore it.
         if (positive && negative) {
@@ -472,7 +526,11 @@
         }
 
         // If positive is true, its positive. If its false, they voted negative.
-        return positive;
+        if (positive) {
+            return VOTE_POSITIVE;
+        }
+
+        return VOTE_NEGATIVE;
     }
 
     /**
@@ -490,7 +548,7 @@
     events.on('github.pull_request.closed', function (data) {
         // Remove this PR from votesPerPR so it no longer shows up on website.
         delete votesPerPR[data.number];
-        
+
         var pr = cachedPRs[data.number];
         if (typeof pr !== 'undefined') {
             pr.state = 'closed';
@@ -508,7 +566,7 @@
         pr.comments.push(data.comment);
         handlePR(pr);
     });
-    
+
     var voting = {};
 
     /**


### PR DESCRIPTION
Vote comments that contain any of the monkey emojis will not be counted.

Monkey emojis are:
- :monkey:`:monkey:`
- :monkey_face:`:monkey_face:`
- :see_no_evil:`:see_no_evil:`
- :hear_no_evil:`:hear_no_evil:`
- :speak_no_evil:`:speak_no_evil:`

It is important that we are able to distinuguish between non-stargazer votes, and real votes.
In the event that a non-stargazer makes a vote, their comment will automatically have the following message appended to the bottom of the vote comment:

> :monkey: @timweightman, we can't count your vote because you must :star:star the repository.
> If you want your vote to count
> - :star:star the repository
> - Wait for **3** minute(s)
> - Remove this message (including the :monkey:`:monkey:`), or post a new vote.

The user name is taken from the vote comment itself, and number of minutes to wait is based on the cached stargazer polling interval.