### PR TITLE
Close voting when guaranteed result after minimum time

### DIFF
--- a/lib/voting.js
+++ b/lib/voting.js
@@ -228,8 +228,6 @@
         });
     }
 
-    setInterval(getStargazerIndex, POLL_INTERVAL);
-
     // returns all results of a paginated function
     function getAllPages(pr, f, cb, n, results) {
         // pr is optional
@@ -355,9 +353,6 @@
         });
     }
 
-    // Repoll all PRs every 30 minutes, just to be safe.
-    setInterval(refreshAllPRs, MINUTE * 30);
-
     /**
      * Fetch all comments for a PR from GitHub.
      */
@@ -382,10 +377,10 @@
 
         // only make a decision if the minimum period has elapsed.
         var age = Date.now() - new Date(pr.created_at).getTime();
-        if (age / MINUTE < PERIOD) { return; }
+        if (age / MINUTE < PERIOD) { return false; }
 
         // only make a decision if we have the minimum amount of votes
-        if (voteResults.total < MIN_VOTES) { return; }
+        if (voteResults.total < MIN_VOTES) { return false; }
 
         // vote passes if yeas > nays
         var passes = decideVoteResult(voteResults.positive, voteResults.negative);
@@ -454,7 +449,7 @@
 
         // Add the PR author as a positive vote by default.
         if (!(pr.user.login in tally.votes)) {
-            tally.votes[pr.user.login] = VOTE_POSITIVE;
+            tally.votes[pr.user.login] = true;
         }
 
         var tallySpread = Object.keys(tally.votes).reduce(function (result, user) {
@@ -578,7 +573,17 @@
         // If we're not set up for GitHub Webhooks, poll the server every interval.
         if (typeof config.githubAuth === 'undefined') {
             setInterval(refreshAllPRs, POLL_INTERVAL);
+        } else {
+            // Repoll all PRs every 30 minutes, just to be safe.
+            setInterval(refreshAllPRs, MINUTE * 30);
         }
+        // Check the stargazers every interval.
+        setInterval(getStargazerIndex, POLL_INTERVAL);
+    };
+
+    voting.testing = {
+      processPR: processPR,
+      cachedStarGazers: cachedStarGazers,
     };
 
     voting.currentVotes = votesPerPR;

--- a/lib/voting.js
+++ b/lib/voting.js
@@ -13,6 +13,7 @@
     var PERIOD_JITTER = 0.2; // fraction of period that is random
     var MIN_VOTES = 8; // minimum number of votes for a decision to be made
     var REQUIRED_SUPERMAJORITY = 0.65;
+    var GUARANTEED_RESULT = Math.ceil(MIN_VOTES * REQUIRED_SUPERMAJORITY);
     var MINUTE = 60 * 1000; // (one minute in ms)
     var POLL_INTERVAL = MINUTE * 3; // how often to check the open PRs (in seconds)
     var VOTE_POSITIVE = ':+1:';
@@ -379,8 +380,10 @@
         var age = Date.now() - new Date(pr.created_at).getTime();
         if (age / MINUTE < PERIOD) { return cb(null, false); }
 
+        var highestVote = Math.max(voteResults.positive, voteResults.negative);
+
         // only make a decision if we have the minimum amount of votes
-        if (voteResults.total < MIN_VOTES) { return cb(null, false); }
+        if (highestVote < GUARANTEED_RESULT) { return cb(null, false); }
 
         // vote passes if yeas > nays
         var passes = decideVoteResult(voteResults.positive, voteResults.negative);
@@ -591,6 +594,7 @@
     voting.minVotes = MIN_VOTES;
     voting.period = PERIOD;
     voting.supermajority = REQUIRED_SUPERMAJORITY;
+    voting.guaranteedResult = GUARANTEED_RESULT;
 
     module.exports = voting;
 }());

--- a/lib/voting.js
+++ b/lib/voting.js
@@ -62,7 +62,7 @@
             });
         }
         return resp;
-    }
+    };
 
     var nonStarGazerComment = function (voteCast, body, user) {
         return (template.render('voting/nonStarGazerVote.md', {
@@ -330,9 +330,7 @@
                 user: config.user,
                 repo: config.repo,
                 number: pr.number
-            }, function (err, res) {
-                cb(err, res);
-            });
+            }, cb);
         });
     }
 
@@ -372,15 +370,17 @@
     /**
      * Tally all of the votes for a PR, and if conditions pass, merge or close it.
      */
-    function processPR(pr) {
+    function processPR(pr, cb) {
+        if (typeof cb === 'undefined') { cb = noop; }
+
         var voteResults = tallyVotes(pr);
 
         // only make a decision if the minimum period has elapsed.
         var age = Date.now() - new Date(pr.created_at).getTime();
-        if (age / MINUTE < PERIOD) { return false; }
+        if (age / MINUTE < PERIOD) { return cb(null, false); }
 
         // only make a decision if we have the minimum amount of votes
-        if (voteResults.total < MIN_VOTES) { return false; }
+        if (voteResults.total < MIN_VOTES) { return cb(null, false); }
 
         // vote passes if yeas > nays
         var passes = decideVoteResult(voteResults.positive, voteResults.negative);
@@ -394,9 +394,9 @@
 
         // Post in IRC
         if (passes) {
-            mergePR(pr, noop);
+            mergePR(pr, cb);
         } else {
-            closePR(pr, noop);
+            closePR(pr, cb);
         }
     }
 
@@ -584,6 +584,7 @@
     voting.testing = {
       processPR: processPR,
       cachedStarGazers: cachedStarGazers,
+      cachedPRs: cachedPRs,
     };
 
     voting.currentVotes = votesPerPR;

--- a/tests/mocks/github.js
+++ b/tests/mocks/github.js
@@ -32,6 +32,29 @@
             });
         },
       },
+
+      pullRequests: {
+        get: function (mergeable) {
+          if (typeof mergeable === 'undefined') { mergeable = true; }
+          return nock(domain)
+            .get(repo + 'pulls/1?' + token)
+            .reply(200, {
+              mergeable: mergeable,
+            });
+        },
+
+        merge: function () {
+          return nock(domain)
+            .put(repo + 'pulls/1/merge?' + token)
+            .reply(200);
+        },
+
+        close: function (pr) {
+          return nock(domain)
+            .patch(repo + 'pulls/1?' + token, { title: pr.title, state: 'closed' })
+            .reply(200);
+        },
+      },
     };
   });
 }());

--- a/tests/mocks/github.js
+++ b/tests/mocks/github.js
@@ -1,0 +1,37 @@
+(function () {
+  'use strict';
+
+  var define = require('amdefine')(module);
+
+  var deps = [
+    'nock',
+    
+    '../../config.js',
+  ];
+
+  define(deps, function (nock, config) {
+    var domain = 'https://api.github.com';
+    var repo = '/repos/' + config.user + '/' + config.repo + '/';
+    var token = 'access_token=' + config.githubAuth.token;
+    //nock.recorder.rec();
+    module.exports = {
+      issues: {
+        createComment: function () {
+          return nock(domain)
+            .post(repo + 'issues/1/comments?' + token)
+            .reply(200, {
+              id: 1,
+            });
+        },
+
+        editComment: function () {
+          return nock(domain)
+            .patch(repo + 'issues/comments/1?' + token)
+            .reply(200, {
+              id: 1,
+            });
+        },
+      },
+    };
+  });
+}());

--- a/tests/unit/voting.js
+++ b/tests/unit/voting.js
@@ -125,8 +125,7 @@
       it('should close failed PRs', function (done) {
         var testPR = _.merge({}, basePR);
         voting.testing.cachedPRs[testPR.number] = testPR;
-        // One less since the ticket creator is already counted.
-        addComments(testPR, 0, voting.minVotes - 1);
+        addComments(testPR, 0, voting.minVotes);
         getVoters(testPR).forEach(function (user) {
           voting.testing.cachedStarGazers[user] = true;
         });
@@ -142,7 +141,7 @@
         });
       });
 
-      it("should process a PR that has a guaranteed win after the time limit", function (done) {
+      it("should merge a PR that has a guaranteed win after the time limit", function (done) {
         var mockPRGet = mock.pullRequests.get(true);
         var mockPRMerge = mock.pullRequests.merge();
         var mockCreateComment = mock.issues.createComment();
@@ -159,6 +158,25 @@
           mockCreateComment.done();
           mockPRGet.done();
           mockPRMerge.done();
+          done();
+        });
+      });
+
+      it("should close a PR that has a guaranteed lose after the time limit", function (done) {
+        var testPR = _.merge({}, basePR);
+        voting.testing.cachedPRs[testPR.number] = testPR;
+        addComments(testPR, 0, voting.guaranteedResult);
+        getVoters(testPR).forEach(function (user) {
+          voting.testing.cachedStarGazers[user] = true;
+        });
+
+        var mockPRClose = mock.pullRequests.close(testPR);
+        var mockCreateComment = mock.issues.createComment();
+
+        var result = voting.testing.processPR(testPR, function (err, res) {
+          if (err) { throw err; }
+          mockCreateComment.done();
+          mockPRClose.done();
           done();
         });
       });

--- a/tests/unit/voting.js
+++ b/tests/unit/voting.js
@@ -107,7 +107,8 @@
         var mockCreateComment = mock.issues.createComment();
         var testPR = _.merge({}, basePR);
         voting.testing.cachedPRs[testPR.number] = testPR;
-        addComments(testPR, 8, 0);
+        // One less since the ticket creator is already counted.
+        addComments(testPR, voting.minVotes - 1, 0);
         getVoters(testPR).forEach(function (user) {
           voting.testing.cachedStarGazers[user] = true;
         });
@@ -124,7 +125,8 @@
       it('should close failed PRs', function (done) {
         var testPR = _.merge({}, basePR);
         voting.testing.cachedPRs[testPR.number] = testPR;
-        addComments(testPR, 0, 8);
+        // One less since the ticket creator is already counted.
+        addComments(testPR, 0, voting.minVotes - 1);
         getVoters(testPR).forEach(function (user) {
           voting.testing.cachedStarGazers[user] = true;
         });
@@ -146,7 +148,8 @@
         var mockCreateComment = mock.issues.createComment();
         var testPR = _.merge({}, basePR);
         voting.testing.cachedPRs[testPR.number] = testPR;
-        addComments(testPR, 6, 0);
+        // One less since the ticket creator is already counted.
+        addComments(testPR, voting.guaranteedResult - 1, 0);
         getVoters(testPR).forEach(function (user) {
           voting.testing.cachedStarGazers[user] = true;
         });
@@ -165,7 +168,8 @@
         // Ten minutes ago
         testPR.created_at = Date.now() - 1000 * 60 * 10;
         voting.testing.cachedPRs[testPR.number] = testPR;
-        addComments(testPR, 6, 0);
+        // One less since the ticket creator is already counted.
+        addComments(testPR, voting.guaranteedResult - 1, 0);
         getVoters(testPR).forEach(function (user) {
           voting.testing.cachedStarGazers[user] = true;
         });

--- a/tests/unit/voting.js
+++ b/tests/unit/voting.js
@@ -1,0 +1,94 @@
+(function () {
+  'use strict';
+
+  var define = require('amdefine')(module);
+
+  var deps = [
+    'assert',
+    'lodash',
+    'nock',
+
+    '../mocks/github.js',
+    '../../lib/voting.js',
+  ];
+
+  define(deps, function (assert, _, nock, mock, voting) {
+    describe('voting', function () {
+      var basePR = {
+        number: 1,
+        title: 'Test PR',
+        html_url: 'http://example.com',
+        created_at: 'Jan 1, 2014',
+        user: {
+          login: 'TestUser',
+        },
+        comments: [],
+      };
+
+      function addComments(pr, positive, negative) {
+        var i;
+        for (i = 0; i < positive; i++) {
+          pr.comments.push({
+            user: { login: 'positive' + i },
+            body: ':+1:',
+            id: 1,
+          });
+        }
+      }
+
+      function getVoters(pr) {
+        return pr.comments.map(function (comment) {
+          return comment.user.login;
+        });
+      }
+
+      function resetStargazers() {
+        Object.keys(voting.testing.cachedStarGazers).forEach(function (name) {
+          delete voting.testing.cachedStarGazers[name];
+        });
+        voting.testing.cachedStarGazers[basePR.user.login] = true;
+      }
+
+      afterEach(function () {
+        resetStargazers();
+      });
+
+      it("should ignore a PR that hasn't been open for long enough", function (done) {
+        var mockCreateComment = mock.issues.createComment();
+        var testPR = _.merge({}, basePR);
+        testPR.created_at = Date.now();
+
+        var result = voting.testing.processPR(testPR);
+        if (result === false) {
+          done();
+        }
+      });
+
+      it("should ignore a PR that doesn't have enough votes", function (done) {
+        var mockCreateComment = mock.issues.createComment();
+        var testPR = _.merge({}, basePR);
+        addComments(testPR, 3, 0);
+        getVoters(testPR).forEach(function (user) {
+          voting.testing.cachedStarGazers[user] = true;
+        });
+
+        var result = voting.testing.processPR(testPR);
+        if (result === false) {
+          done();
+        }
+      });
+
+      it("should edit non-stargazers' comments", function (done) {
+        var mockEditComment = mock.issues.editComment();
+        var testPR = _.merge({}, basePR);
+        addComments(testPR, 3, 0);
+        getVoters(testPR).slice(0, -1).forEach(function (user) {
+          voting.testing.cachedStarGazers[user] = true;
+        });
+
+        var result = voting.testing.processPR(testPR);
+        return mockEditComment.isDone() ? done() : assert.ifError('Comment not edited');
+      });
+    });
+  });
+}());


### PR DESCRIPTION
Most of this PR is writing tests to ensure that voting occurs as expected, however there is a small change to voting that calculates the minimum number of votes required for a guaranteed win/lose, after the time limit has passed.

If there are fewer than the minimum number of votes when the minimum period elapses, a result may be guaranteed if `(MIN_VOTES * REQUIRED_SUPERMAJORITY)` is greater than the most votes for either positive or negative.

Example:
If this PR gets 6 votes for yes, and only one vote for no, it will be merged in.
If this PR gets 4 votes for yes, and none for no, it will not have the minimum for a guaranteed result (which would be 6), and will remain open.
If this PR gets 4 votes for yes, and 4 votes for no, it will be an even split, and will remain open until one side gains majority.