### PR TITLE
No longer tweet twice after a merge.

### DIFF
--- a/lib/integrations/twitter.js
+++ b/lib/integrations/twitter.js
@@ -42,6 +42,11 @@
 
             function eventPullRequestClosed(event) {
                 var pr = event.pull_request;
+
+                // Closed event fires for both merged and rejected scenarios, so
+                // we must exit if the vote was successful and PR merged.
+                if (pr.merged_at !== null) { return; }
+
                 // Tweet PR closed
                 postTweet('PR #' + pr.number + ' has been closed: ' + pr.html_url);
             }


### PR DESCRIPTION
Noticed this bug. Fixed this bug. https://twitter.com/anythingbot

It's kindof bad that we duplicate this logic everywhere, but `¯\_(ツ)_/¯`