### PR TITLE
Added Procfile to repository root

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+bot: npm run main

--- a/README.md
+++ b/README.md
@@ -72,8 +72,10 @@ $ cat configs/custom.js
 
 ```
 1. (Optional) Set up GitHub Webhooks by following the next section.
+1. (Optional) Install foreman  with `gem install foreman`
 1. Run `npm install` to install dependencies.
-1. Run `node main.js` to start the bot.
+1. Run `node main.js` to start the bot. Alternatively, if you installed foreman earlier, `foreman start` will also 
+start the bot as well as giving slightly prettier console output.
 
 ## Setting up GitHub Webhooks
 


### PR DESCRIPTION
This adds a simple Procfile to the root of the repository, allowing the tool 'foreman' to be used to stop/start the bot. Aside from providing prettier console output, it will make it easier to manage the bot if it ever becomes multi-process (e.g a Redis server or a component written in another language)