### PR TITLE
Twitter should not double tweet

### DIFF
--- a/lib/integrations/twitter.js
+++ b/lib/integrations/twitter.js
@@ -42,6 +42,11 @@
 
             function eventPullRequestClosed(event) {
                 var pr = event.pull_request;
+
+                // Closed event fires for both merged and rejected scenarios, so
+                // we must exit if the vote was successful and PR merged.
+                if (pr.merged_at !== null) { return; }
+
                 // Tweet PR closed
                 postTweet('PR #' + pr.number + ' has been closed: ' + pr.html_url);
             }

--- a/lib/integrations/twitter.js
+++ b/lib/integrations/twitter.js
@@ -45,7 +45,7 @@
 
                 // Closed event fires for both merged and rejected scenarios, so
                 // we must exit if the vote was successful and PR merged.
-                if (pr.merged_at !== null) { return; }
+                if (pr.merged_at) { return; }
 
                 // Tweet PR closed
                 postTweet('PR #' + pr.number + ' has been closed: ' + pr.html_url);

--- a/tests/unit/twitter.js
+++ b/tests/unit/twitter.js
@@ -31,6 +31,15 @@
         },
       };
 
+      var mockMergeEvent = {
+        pull_request: {
+          number: 1,
+          title: 'Test Twitter functionality',
+          html_url: 'http://example.com/',
+          merged_at: '2011-01-26T19:01:12Z',
+        },
+      };
+
       it('When a bot.pull_request.vote_started event occurs, it should tweet', function (done) {
         events.emit('bot.pull_request.vote_started', mockEvent.pull_request);
         setTimeout(function () {
@@ -40,7 +49,7 @@
       });
 
       it('When a github.pull_request.merged event occurs, it should tweet', function (done) {
-        events.emit('github.pull_request.merged', mockEvent);
+        events.emit('github.pull_request.merged', mockMergeEvent);
         setTimeout(function () {
           return mocked.isDone() ? done() : assert.ifError('Mocks not yet satisfied');
         }, 10);

--- a/tests/unit/twitter.js
+++ b/tests/unit/twitter.js
@@ -4,7 +4,7 @@
   var deps = [
     'assert',
     'nock',
-    'underscore',
+    'lodash',
 
     '../mocks/twitter.js',
     '../../lib/integrations/twitter.js',

--- a/tests/unit/twitter.js
+++ b/tests/unit/twitter.js
@@ -4,13 +4,14 @@
   var deps = [
     'assert',
     'nock',
+    'underscore',
 
     '../mocks/twitter.js',
     '../../lib/integrations/twitter.js',
     '../../lib/events.js',
   ];
 
-  define(deps, function (assert, nock, mock, twitter, events) {
+  define(deps, function (assert, nock, _, mock, twitter, events) {
     describe('twitter', function () {
       var mocked;
       var twitterInstance;
@@ -31,14 +32,11 @@
         },
       };
 
-      var mockMergeEvent = {
-        pull_request: {
-          number: 1,
-          title: 'Test Twitter functionality',
-          html_url: 'http://example.com/',
-          merged_at: '2011-01-26T19:01:12Z',
-        },
-      };
+      var mockMergeEvent =
+        _.extend(
+          {},
+          mockEvent,
+          { merged_at: '2011-01-26T19:01:12Z' });
 
       it('When a bot.pull_request.vote_started event occurs, it should tweet', function (done) {
         events.emit('bot.pull_request.vote_started', mockEvent.pull_request);


### PR DESCRIPTION
Re-rolling #400, #401, and #403 

Noticed this bug. Fixed this bug. https://twitter.com/anythingbot

It's kindof bad that we duplicate this logic everywhere, but `¯\_(ツ)_/¯`