### PR TITLE
Use unescaped HTML for the voting ended comment template's pass/fail text

### DIFF
--- a/data/templates/voting/voteEnded.md
+++ b/data/templates/voting/voteEnded.md
@@ -1,4 +1,4 @@
-#### {{passFail}}
+#### {{{passFail}}}
 
 
 ----


### PR DESCRIPTION
This should fix the vote ended comment to ensure it shows the cat picture properly.

The HTML was being escaped by the markdown template, because I did not use the `{{{unescaped-html}}}` variable.