### PR TITLE
Voting Refactor and Multiple Repository Support

### DIFF
--- a/configs/template.js
+++ b/configs/template.js
@@ -33,6 +33,13 @@
             channel: '#botwillacceptanything',
         },
         */
+       voting: {
+         period: 15,
+         period_jitter: 0.2,
+         minVotes: 8,
+         supermajority: 0.65,
+         pollInterval: 3, // Minutes
+       },
 
     };
 }());

--- a/data/views/votes.hbs
+++ b/data/views/votes.hbs
@@ -1,9 +1,14 @@
-<ul style="display: inline-block">
-    {{#each votes}}
-        <li>
-          #{{this.pr.number}} - {{this.pr.title}} by <strong>{{this.pr.user.login}}</strong> -
-          Yes: {{this.votes.positive}}, No: {{this.votes.negative}} -
-          <a href="{{this.pr.html_url}}" target="_blank">Pull Request</a>
-        </li>
+{{#each repositories}}
+  <h2>{{this.repo.user}}/{{this.repo.repo}}</h2>
+  <ul style="display: inline-block">
+    {{#each this.votesPerPR}}
+      <li>
+        #{{this.pr.number}} - {{this.pr.title}} by <strong>{{this.pr.user.login}}</strong> -
+        Yes: {{this.votes.positive}}, No: {{this.votes.negative}} -
+        <a href="{{this.pr.html_url}}" target="_blank">Pull Request</a>
+      </li>
+    {{else}}
+      <li>No votes in progress</li>
     {{/each}}
-</ul>
+  </ul>
+{{/each}}

--- a/lib/github.js
+++ b/lib/github.js
@@ -3,6 +3,7 @@
 
   var config = require('../config.js');
   var Github = require('github');
+  var _ = require('lodash');
 
   var gh = new Github({
     version: '3.0.0',
@@ -11,6 +12,33 @@
     }
   });
   gh.authenticate(config.githubAuth);
+
+  /**
+   * Provide a function for getting all pages of an API request.
+   */
+  gh.getAllPages = function getAllPages(repo, f, cb, n, results) {
+    if (!results) { results = []; }
+    if (!n) { n = 0; }
+
+    var repoRequest = _.merge({}, repo, {
+      page: n,
+      per_page: 100,
+    });
+
+    f(repoRequest, function (err, res) {
+      if (err || !res) { return cb(err); }
+
+      results = results.concat(res);
+
+      // if we got to the end of the results, return them
+      if (res.length < 100) {
+        return cb(null, results);
+      }
+
+      // otherwise keep getting more pages recursively
+      getAllPages(repo, f, cb, n + 1, results);
+    });
+  };
 
   module.exports = gh;
 }());

--- a/lib/integrations/github_labels.js
+++ b/lib/integrations/github_labels.js
@@ -6,10 +6,11 @@
     var deps = [
         '../github',
         '../../config',
+        '../repositories',
         '../events'
     ];
 
-    define(deps, function (gh, config, events) {
+    define(deps, function (gh, config, repositories, events) {
         module.exports = function () {
             var VOTING_UNDERWAY = 'Voting Underway',
                 VOTING_REJECTED = 'Rejected',
@@ -20,32 +21,37 @@
                     { name: VOTING_MERGED, color: '88C451' }
                 ];
 
-            gh.issues.getLabels({
-                user: config.user,
-                repo: config.repo
-            }, function (err, repoLabels) {
-                ensureRepoHasLabels(voteStatusLabels, repoLabels);
+            repositories.forEach(function (repo) {
+                gh.issues.getLabels({
+                    user: repo.user,
+                    repo: repo.repo
+                }, function (err, repoLabels) {
+                    ensureRepoHasLabels(repo, voteStatusLabels, repoLabels);
+                });
             });
 
             events.on('bot.pull_request.vote_started', function (pr) {
-                setPrStatusLabel(getStatusLabel(VOTING_UNDERWAY), pr);
+                var repo = { repo: data.repository.name, user: self.repo.user };
+                setPrStatusLabel(repo, getStatusLabel(VOTING_UNDERWAY), pr);
             });
 
             events.on('github.pull_request.closed', function (event) {
                 var pr = event.pull_request;
+                var repo = { repo: data.repository.name, user: self.repo.user };
 
                 // Closed event fires for both merged and rejected scenarios, so
                 // we must exit if the vote was successful and PR merged.
                 if (pr.merged_at !== null) { return; }
 
                 // Voting has rejected the PR.
-                setPrStatusLabel(getStatusLabel(VOTING_REJECTED), pr);
+                setPrStatusLabel(repo, getStatusLabel(VOTING_REJECTED), pr);
             });
 
             events.on('github.pull_request.merged', function (event) {
                 var pr = event.pull_request;
+                var repo = { repo: data.repository.name, user: self.repo.user };
 
-                setPrStatusLabel(getStatusLabel(VOTING_MERGED), pr);
+                setPrStatusLabel(repo, getStatusLabel(VOTING_MERGED), pr);
             });
 
             function noop(err) {
@@ -64,11 +70,11 @@
                 return voteStatusLabels[indexOfLabel];
             }
 
-            function setPrStatusLabel(label, pr) {
+            function setPrStatusLabel(repo, label, pr) {
                 // Fetch the issue labels for this pull request
                 gh.issues.getIssueLabels({
-                    user: config.user,
-                    repo: config.repo,
+                    user: repo.user,
+                    repo: repo.repo,
                     number: pr.number
                 }, function (err, prLabels) {
                     if (err) {
@@ -114,10 +120,10 @@
                 });
             }
 
-            function applyNewPrLabels(prLabels, pr) {
+            function applyNewPrLabels(repo, prLabels, pr) {
                 gh.issues.edit({
-                    user: config.user,
-                    repo: config.repo,
+                    user: repo.user,
+                    repo: repo.repo,
                     number: pr.number,
                     labels: prLabels
                 }, noop);
@@ -125,14 +131,14 @@
 
             // Create any labels that haven't already been created.
             // If all required labels already exist in the repo, this will do nothing.
-            function ensureRepoHasLabels (requiredLabels, repoLabels) {
+            function ensureRepoHasLabels(repo, requiredLabels, repoLabels) {
                 var toCreate = findLabelsToCreate(requiredLabels, repoLabels);
 
                 toCreate.forEach(function (requiredLabel, index) {
                     // Repo doesn't have this label. Create it.
                     gh.issues.createLabel({
-                        user: config.user,
-                        repo: config.repo,
+                        user: repo.user,
+                        repo: repo.repo,
                         name: requiredLabel.name,
                         color: requiredLabel.color
                     }, noop);

--- a/lib/integrations/github_labels.js
+++ b/lib/integrations/github_labels.js
@@ -31,13 +31,13 @@
             });
 
             events.on('bot.pull_request.vote_started', function (pr) {
-                var repo = { repo: data.repository.name, user: self.repo.user };
+                var repo = { repo: pr.head.repo.name, user: pr.head.user.login };
                 setPrStatusLabel(repo, getStatusLabel(VOTING_UNDERWAY), pr);
             });
 
             events.on('github.pull_request.closed', function (event) {
                 var pr = event.pull_request;
-                var repo = { repo: data.repository.name, user: self.repo.user };
+                var repo = { repo: pr.head.repo.name, user: pr.head.user.login };
 
                 // Closed event fires for both merged and rejected scenarios, so
                 // we must exit if the vote was successful and PR merged.
@@ -49,7 +49,7 @@
 
             events.on('github.pull_request.merged', function (event) {
                 var pr = event.pull_request;
-                var repo = { repo: data.repository.name, user: self.repo.user };
+                var repo = { repo: pr.head.repo.name, user: pr.head.user.login };
 
                 setPrStatusLabel(repo, getStatusLabel(VOTING_MERGED), pr);
             });
@@ -109,7 +109,7 @@
                     // Add the status label that we want
                     prLabels.push(label);
 
-                    applyNewPrLabels(prLabels, pr);
+                    applyNewPrLabels(repo, prLabels, pr);
                 });
             }
 

--- a/lib/repositories.js
+++ b/lib/repositories.js
@@ -1,0 +1,40 @@
+(function () {
+  'use strict';
+
+  var define = require('amdefine')(module);
+
+  var deps = [
+    'lodash',
+
+    '../config',
+  ];
+
+  define(deps, function (_, config) {
+    var repos = [
+      {
+        repo: config.repo,
+        user: config.user,
+        votingConfig: config.voting,
+        main: true,
+      },
+    ];
+
+    if (typeof config.additionalRepos !== 'undefined') {
+      config.additionalRepos.forEach(function (repo) {
+        var votingConfig = _.merge({}, config.voting);
+        // Merge in repo-specific voting configurations.
+        if (typeof repo.voting !== 'undefined') {
+          _.merge(votingConfig, repo.voting);
+        }
+        repos.push({
+          repo: repo.repo,
+          user: repo.user,
+          votingConfig: votingConfig,
+          main: false,
+        });
+      });
+    }
+
+    module.exports = repos;
+  });
+}());

--- a/lib/routes/votes.js
+++ b/lib/routes/votes.js
@@ -12,7 +12,7 @@
     function RouteVotes(app) {
       app.get('/votes', function (req, res) {
         var data = {
-          votes: voting.currentVotes,
+          repositories: voting.instances,
         };
         res.render('votes', data);
       });

--- a/lib/voting/index.js
+++ b/lib/voting/index.js
@@ -8,6 +8,14 @@
     ];
 
     define(deps, function(Voting) {
-        module.exports = Voting;
+        var voting = {
+          instances: [],
+        };
+
+        voting.setup = function (repo) {
+          voting.instances.push(new Voting(repo));
+        };
+
+        module.exports = voting;
     });
 }());

--- a/lib/voting/templates.js
+++ b/lib/voting/templates.js
@@ -70,7 +70,6 @@
           nonStarGazers: nonStarGazerMap,
         };
 
-        updateKittenImage();
         templates.updateKittenImage();
         return template.render('voting/voteEnded.md', voteEndedData);
       };

--- a/lib/voting/templates.js
+++ b/lib/voting/templates.js
@@ -16,23 +16,6 @@
       return Math.floor(n * 1000) / 10;
     }
 
-    /**
-     * Get a random kitten to be used by the bot.
-     */
-    function updateKittenImage() {
-      request('https://thecatapi.com/api/images/get?format=html', function (err, resp, body) {
-        if (err) {
-          console.error(err);
-          console.error(err.stack);
-          return;
-        }
-        kitten = body;
-      });
-    }
-
-    // Immediately fetch a new kitten image.
-    updateKittenImage();
-
     module.exports = function (votingConfig) {
       var templates = {
         votePassComment: template.render('voting/votePassComment.md'),
@@ -45,6 +28,22 @@
           majority: votingConfig.supermajority * 100,
           min_votes: votingConfig.minVotes,
         }),
+      };
+
+      /**
+       * Get a random kitten to be used by the bot.
+       */
+      templates.updateKittenImage = function updateKittenImage() {
+        var self = this;
+
+        request('https://thecatapi.com/api/images/get?format=html', function (err, resp, body) {
+          if (err) {
+            console.error(err);
+            console.error(err.stack);
+            return;
+          }
+          kitten = body;
+        });
       };
 
       templates.voteEndComment = function (pass, yea, nay, nonStarGazers) {
@@ -72,6 +71,7 @@
         };
 
         updateKittenImage();
+        templates.updateKittenImage();
         return template.render('voting/voteEnded.md', voteEndedData);
       };
 
@@ -83,6 +83,12 @@
           stargazerRefreshInterval: votingConfig.pollInterval,
         }));
       };
+
+
+      if (process.env.BUILD_ENVIRONMENT !== 'test') {
+        // Immediately fetch a new kitten image.
+        templates.updateKittenImage();
+      }
 
       return templates;
     };

--- a/lib/voting/templates.js
+++ b/lib/voting/templates.js
@@ -1,0 +1,90 @@
+(function () {
+  'use strict';
+
+  var define = require('amdefine')(module);
+
+  var deps = [
+    'request',
+
+    '../template',
+  ];
+
+  define(deps, function (request, template) {
+    var kitten = '';
+
+    function percent(n) {
+      return Math.floor(n * 1000) / 10;
+    }
+
+    /**
+     * Get a random kitten to be used by the bot.
+     */
+    function updateKittenImage() {
+      request('https://thecatapi.com/api/images/get?format=html', function (err, resp, body) {
+        if (err) {
+          console.error(err);
+          console.error(err.stack);
+          return;
+        }
+        kitten = body;
+      });
+    }
+
+    // Immediately fetch a new kitten image.
+    updateKittenImage();
+
+    module.exports = function (votingConfig) {
+      var templates = {
+        votePassComment: template.render('voting/votePassComment.md'),
+        voteFailComment: template.render('voting/voteFailComment.md'),
+        modifiedWarning: template.render('voting/modifiedWarning.md'),
+        couldntMergeWarning: template.render('voting/couldntMergeWarning.md'),
+        voteStartedComment: template.render('voting/voteStarted.md', {
+          period: votingConfig.period,
+          jitter: votingConfig.period_jitter * 100 / 2,
+          majority: votingConfig.supermajority * 100,
+          min_votes: votingConfig.minVotes,
+        }),
+      };
+
+      templates.voteEndComment = function (pass, yea, nay, nonStarGazers) {
+        var total = yea + nay;
+        var yeaPercent = percent(yea / total);
+        var nayPercent = percent(nay / total);
+
+        // Map nonStarGazer user names to an object list that's better
+        // for Mustache template.
+        var nonStarGazerMap = nonStarGazers.map(function (user, index) {
+          return {
+            name: user,
+            first: (index === 0),
+            last: (index === (nonStarGazers.length - 1)),
+          };
+        });
+
+        var voteEndedData = {
+          passFail: (pass ? (kitten + templates.votePassComment) : templates.voteFailComment),
+          yea: yea,
+          nay: nay,
+          yeaPercent: yeaPercent,
+          nayPercent: nayPercent,
+          nonStarGazers: nonStarGazerMap,
+        };
+
+        updateKittenImage();
+        return template.render('voting/voteEnded.md', voteEndedData);
+      };
+
+      templates.nonStarGazerComment = function (voteCast, body, user) {
+        return (template.render('voting/nonStarGazerVote.md', {
+          user: user,
+          body: body,
+          vote: voteCast,
+          stargazerRefreshInterval: votingConfig.pollInterval,
+        }));
+      };
+
+      return templates;
+    };
+  });
+}());

--- a/lib/voting/votes.js
+++ b/lib/voting/votes.js
@@ -7,9 +7,11 @@
     'lodash',
 
     '../events',
+    '../github',
+    './templates',
   ];
 
-  define(deps, function (_, events) {
+  define(deps, function (_, events, gh, templates) {
     var VOTE_POSITIVE = ':+1:';
     var VOTE_NEGATIVE = ':-1:';
     var VOTE_MONKEY = [':monkey:', ':monkey_face:', ':hear_no_evil:',':see_no_evil:',':speak_no_evil:'];
@@ -25,13 +27,12 @@
       }
     }
 
-
-
     var VoteController = function VoteController(repo, votingConfig, starGazers, votesPerPR) {
       this.repo = repo;
       this.votingConfig = votingConfig;
       this.starGazers = starGazers;
       this.votesPerPR = votesPerPR;
+      this.templates = templates(this.votingConfig);
     };
 
     /**
@@ -59,7 +60,7 @@
               user: self.repo.user,
               repo: self.repo.repo,
               id: comment.id,
-              body: nonStarGazerComment(voteCast, body, user)
+              body: self.templates.nonStarGazerComment(voteCast, body, user)
             }, noop);
           }
           return result;

--- a/lib/voting/votes.js
+++ b/lib/voting/votes.js
@@ -1,0 +1,174 @@
+(function () {
+  'use strict';
+
+  var define = require('amdefine')(module);
+
+  var deps = [
+    'lodash',
+
+    '../events',
+  ];
+
+  define(deps, function (_, events) {
+    var VOTE_POSITIVE = ':+1:';
+    var VOTE_NEGATIVE = ':-1:';
+    var VOTE_MONKEY = [':monkey:', ':monkey_face:', ':hear_no_evil:',':see_no_evil:',':speak_no_evil:'];
+
+    function percent(n) {
+      return Math.floor(n * 1000) / 10;
+    }
+
+    function noop(err) {
+      if (err) {
+        console.error(err);
+        console.error(err.stack);
+      }
+    }
+
+
+
+    var VoteController = function VoteController(repo, votingConfig, starGazers, votesPerPR) {
+      this.repo = repo;
+      this.votingConfig = votingConfig;
+      this.starGazers = starGazers;
+      this.votesPerPR = votesPerPR;
+    };
+
+    /**
+     * Tally up the votes on a PR, and monitor which users are stargazers.
+     */
+    VoteController.prototype.tallyVotes = function tallyVotes(pr) {
+      var self = this;
+
+      var tally = pr.comments.reduce(function (result, comment) {
+        var user = comment.user.login,
+          body = comment.body,
+          voteCast = self.calculateUserVote(body);
+
+        // People that don't star the repo cannot vote.
+        if (!self.starGazers[user]) {
+          if (result.nonStarGazers.indexOf(user) === -1) {
+            result.nonStarGazers.push(user);
+          }
+
+          if (voteCast !== VOTE_MONKEY && voteCast !== null) {
+            // This comment has not yet been marked as a monkey, but should be.
+            // The user is not a stargazer, but has made a vote-style comment.
+            // Edit the comment with a monkey warning appended to the end.
+            gh.issues.editComment({
+              user: self.repo.user,
+              repo: self.repo.repo,
+              id: comment.id,
+              body: nonStarGazerComment(voteCast, body, user)
+            }, noop);
+          }
+          return result;
+        }
+
+        // Only record votes that are explicitly
+        // positive, or negative.
+        // Monkeys and votes that go both ways
+        // do not record a result.
+        if (voteCast === VOTE_POSITIVE) {
+          result.votes[user] = true;
+        }
+
+        if (voteCast === VOTE_NEGATIVE) {
+          result.votes[user] = false;
+        }
+
+        return result;
+      }, {
+        votes: {},
+        nonStarGazers: [],
+      });
+
+      // Add the PR author as a positive vote by default.
+      if (!(pr.user.login in tally.votes)) {
+        tally.votes[pr.user.login] = true;
+      }
+
+      var tallySpread = Object.keys(tally.votes).reduce(function (result, user) {
+        // Increment the positive/negative counters.
+        if (tally.votes[user]) {
+          result.positive++;
+        } else {
+          result.negative++;
+        }
+
+        result.total++;
+        return result;
+      }, {
+        positive: 0,
+        negative: 0,
+        total: 0
+      });
+
+      tallySpread.percentPositive = percent(tallySpread.positive / tallySpread.total);
+      tallySpread.percentNegative = percent(tallySpread.negative / tallySpread.total);
+
+      _.merge(tally, tallySpread);
+
+      // Store this so that we can eventually make a votes webserver endpoint.
+      this.votesPerPR[pr.number] = { pr: pr, votes: tally };
+      events.emit('bot.pull_request.votes', pr, tally);
+
+      return tally;
+    }
+
+    /**
+     * Check the text of a comment, and determine what vote was cast.
+     */
+    VoteController.prototype.calculateUserVote = function calculateUserVote(text) {
+      var positive = this.isPositive(text),
+        negative = this.isNegative(text),
+        monkey = this.isMonkey(text);
+
+      if (monkey) {
+        return VOTE_MONKEY;
+      }
+
+      // If the user has voted positive and negative, or hasn't voted, ignore it.
+      if (positive && negative) {
+        return null;
+      }
+      if (!positive && !negative) {
+        return null;
+      }
+
+      // If positive is true, its positive. If its false, they voted negative.
+      if (positive) {
+        return VOTE_POSITIVE;
+      }
+
+      return VOTE_NEGATIVE;
+    }
+
+    // Returns true if the text contains a positive vote
+    VoteController.prototype.isPositive = function isPositive (text) {
+      return (text.indexOf(VOTE_POSITIVE) !== -1);
+    }
+
+    // Returns true if the text contains a negative vote
+    VoteController.prototype.isNegative = function isNegative (text) {
+      return (text.indexOf(VOTE_NEGATIVE) !== -1);
+    }
+
+    // Returns true if the text is a monkey vote.
+    VoteController.prototype.isMonkey = function isMonkey (text) {
+      // VOTE_MONKEY is an array of monkey vote keys.
+      // If any of those keys appears in the text, the
+      // vote is a monkey.
+      return VOTE_MONKEY.some(function (monkey) {
+        return (text.indexOf(monkey) !== -1);
+      });
+    }
+
+
+    VoteController.prototype.doesVotePass = function doesVotePass(positive, negative) {
+      return (positive / (positive + negative)) > this.votingConfig.supermajority;
+    };
+
+    module.exports = VoteController;
+  });
+}());

--- a/lib/voting/votes.js
+++ b/lib/voting/votes.js
@@ -114,7 +114,7 @@
       events.emit('bot.pull_request.votes', pr, tally);
 
       return tally;
-    }
+    };
 
     /**
      * Check the text of a comment, and determine what vote was cast.
@@ -142,17 +142,17 @@
       }
 
       return VOTE_NEGATIVE;
-    }
+    };
 
     // Returns true if the text contains a positive vote
     VoteController.prototype.isPositive = function isPositive (text) {
       return (text.indexOf(VOTE_POSITIVE) !== -1);
-    }
+    };
 
     // Returns true if the text contains a negative vote
     VoteController.prototype.isNegative = function isNegative (text) {
       return (text.indexOf(VOTE_NEGATIVE) !== -1);
-    }
+    };
 
     // Returns true if the text is a monkey vote.
     VoteController.prototype.isMonkey = function isMonkey (text) {
@@ -162,7 +162,7 @@
       return VOTE_MONKEY.some(function (monkey) {
         return (text.indexOf(monkey) !== -1);
       });
-    }
+    };
 
 
     VoteController.prototype.doesVotePass = function doesVotePass(positive, negative) {

--- a/lib/voting/votes.js
+++ b/lib/voting/votes.js
@@ -12,10 +12,6 @@
   ];
 
   define(deps, function (_, events, gh, templates) {
-    var VOTE_POSITIVE = ':+1:';
-    var VOTE_NEGATIVE = ':-1:';
-    var VOTE_MONKEY = [':monkey:', ':monkey_face:', ':hear_no_evil:',':see_no_evil:',':speak_no_evil:'];
-
     function percent(n) {
       return Math.floor(n * 1000) / 10;
     }
@@ -33,6 +29,9 @@
       this.starGazers = starGazers;
       this.votesPerPR = votesPerPR;
       this.templates = templates(this.votingConfig);
+      this.votePositive = ':+1:';
+      this.voteNegative = ':-1:';
+      this.voteMonkey = [':monkey:', ':monkey_face:', ':hear_no_evil:',':see_no_evil:',':speak_no_evil:'];
     };
 
     /**
@@ -52,7 +51,7 @@
             result.nonStarGazers.push(user);
           }
 
-          if (voteCast !== VOTE_MONKEY && voteCast !== null) {
+          if (voteCast !== self.voteMonkey && voteCast !== null) {
             // This comment has not yet been marked as a monkey, but should be.
             // The user is not a stargazer, but has made a vote-style comment.
             // Edit the comment with a monkey warning appended to the end.
@@ -70,11 +69,11 @@
         // positive, or negative.
         // Monkeys and votes that go both ways
         // do not record a result.
-        if (voteCast === VOTE_POSITIVE) {
+        if (voteCast === self.votePositive) {
           result.votes[user] = true;
         }
 
-        if (voteCast === VOTE_NEGATIVE) {
+        if (voteCast === self.voteNegative) {
           result.votes[user] = false;
         }
 
@@ -126,7 +125,7 @@
         monkey = this.isMonkey(text);
 
       if (monkey) {
-        return VOTE_MONKEY;
+        return this.voteMonkey;
       }
 
       // If the user has voted positive and negative, or hasn't voted, ignore it.
@@ -139,28 +138,28 @@
 
       // If positive is true, its positive. If its false, they voted negative.
       if (positive) {
-        return VOTE_POSITIVE;
+        return this.votePositive;
       }
 
-      return VOTE_NEGATIVE;
+      return this.voteNegative;
     };
 
     // Returns true if the text contains a positive vote
     VoteController.prototype.isPositive = function isPositive (text) {
-      return (text.indexOf(VOTE_POSITIVE) !== -1);
+      return (text.indexOf(this.votePositive) !== -1);
     };
 
     // Returns true if the text contains a negative vote
     VoteController.prototype.isNegative = function isNegative (text) {
-      return (text.indexOf(VOTE_NEGATIVE) !== -1);
+      return (text.indexOf(this.voteNegative) !== -1);
     };
 
     // Returns true if the text is a monkey vote.
     VoteController.prototype.isMonkey = function isMonkey (text) {
-      // VOTE_MONKEY is an array of monkey vote keys.
+      // this.voteMonkey is an array of monkey vote keys.
       // If any of those keys appears in the text, the
       // vote is a monkey.
-      return VOTE_MONKEY.some(function (monkey) {
+      return this.voteMonkey.some(function (monkey) {
         return (text.indexOf(monkey) !== -1);
       });
     };

--- a/lib/voting/voting.js
+++ b/lib/voting/voting.js
@@ -49,6 +49,16 @@
         this.voteController = new VoteController(repo, votingConfig, this.starGazers, this.votesPerPR);
         this.templates = templates(this.votingConfig);
 
+        // Only initialize the regular polling if the bot is not being tested.
+        if (process.env.BUILD_ENVIRONMENT !== 'test') {
+          this.initialize();
+        }
+
+        // Initialize our event handling.
+        this.initializeEvents();
+      };
+
+      Voting.prototype.initialize = function initialize() {
         this.updateStarGazers(this.refreshAllPRs.bind(this));
 
         // If we're not set up for GitHub Webhooks, poll the server every interval.
@@ -60,7 +70,9 @@
         }
         // Check the stargazers every interval.
         setInterval(this.updateStarGazers.bind(this), this.votingConfig.pollInterval * MINUTE);
+      };
 
+      Voting.prototype.initializeEvents = function initializeEvents() {
         /**
          * When a pull request is opened, add it to the cache and handle it.
          */

--- a/lib/voting/voting.js
+++ b/lib/voting/voting.js
@@ -32,7 +32,7 @@
       }
 
 
-      var Voting = function Voting(repo, votingConfig) {
+      var Voting = function Voting(repo) {
         var self = this;
 
         this.starGazers = {};
@@ -41,12 +41,12 @@
         this.votesPerPR = {};
 
         this.repo = repo;
-        this.votingConfig = votingConfig;
+        this.votingConfig = repo.votingConfig;
         this.votingConfig.truePeriod =
-          this.votingConfig.period * (1 + (Math.random() - 0.5) * votingConfig.period_jitter);
+          this.votingConfig.period * (1 + (Math.random() - 0.5) * this.votingConfig.period_jitter);
         this.votingConfig.guaranteedResult =
           Math.ceil(this.votingConfig.minVotes * this.votingConfig.supermajority);
-        this.voteController = new VoteController(repo, votingConfig, this.starGazers, this.votesPerPR);
+        this.voteController = new VoteController(repo, this.votingConfig, this.starGazers, this.votesPerPR);
         this.templates = templates(this.votingConfig);
 
         // Only initialize the regular polling if the bot is not being tested.

--- a/lib/voting/voting.js
+++ b/lib/voting/voting.js
@@ -59,6 +59,7 @@
       };
 
       Voting.prototype.initialize = function initialize() {
+        // Immediately update the stargazers, and fetch and process all PRs.
         this.updateStarGazers(this.refreshAllPRs.bind(this));
 
         // If we're not set up for GitHub Webhooks, poll the server every interval.
@@ -73,10 +74,18 @@
       };
 
       Voting.prototype.initializeEvents = function initializeEvents() {
+        var self = this;
+
         /**
          * When a pull request is opened, add it to the cache and handle it.
          */
         events.on('github.pull_request.opened', function (data) {
+          // Don't process events for other repositories.
+          if (data.repository.name !== self.repo.repo ||
+              data.repository.owner.login !== self.repo.user) {
+            return;
+          }
+
           data.pull_request.comments = [];
           self.pullRequests[data.number] = data.pull_request;
           self.handlePR(data.pull_request);
@@ -86,6 +95,12 @@
          * When a pull request is closed, mark it so we don't process it again.
          */
         events.on('github.pull_request.closed', function (data) {
+          // Don't process events for other repositories.
+          if (data.repository.name !== self.repo.repo ||
+              data.repository.owner.login !== self.repo.user) {
+            return;
+          }
+
           // Remove this PR from votesPerPR so it no longer shows up on website.
           delete self.votesPerPR[data.number];
 
@@ -99,6 +114,12 @@
          * When a comment is created, push it onto the PR, and handle the PR again.
          */
         events.on('github.comment.created', function (data) {
+          // Don't process events for other repositories.
+          if (data.repository.name !== self.repo.repo ||
+              data.repository.owner.login !== self.repo.user) {
+            return;
+          }
+
           var pr = self.pullRequests[data.issue.number];
           if (typeof pr === 'undefined') {
             return console.error('Could not find PR', data.issue.number, 'when adding a comment');
@@ -124,10 +145,14 @@
           }
 
           var index = {};
-          stargazers.forEach(function (stargazer) {
-            index[stargazer.login] = true;
+          // Erase the existing stargazers.
+          Object.keys(self.starGazers).forEach(function (stargazer) {
+            delete self.starGazers[stargazer];
           });
-          self.starGazers = index;
+          // Add in the updated list of stargazers.
+          stargazers.forEach(function (stargazer) {
+            self.starGazers[stargazer.login] = true;
+          });
           console.log('Got stargazers for ' + self.repo.user + '/' + self.repo.repo);
           if (typeof cb === 'function') {
             cb(stargazers);

--- a/lib/voting/voting.js
+++ b/lib/voting/voting.js
@@ -3,620 +3,390 @@
 
     var deps = [
         'lodash',
-        'request',
         'sentiment',
 
         '../../config',
         '../events',
         '../github',
-        '../template'
+        './templates',
+        './votes.js',
     ];
 
     define(deps, function(
         _,
-        request,
         sentiment,
 
         config,
         events,
         gh,
-        template
+        templates,
+        VoteController
     ) {
-        // voting settings
-        var PERIOD = 15; // time for the vote to be open, in minutes
-        var PERIOD_JITTER = 0.2; // fraction of period that is random
-        var MIN_VOTES = 8; // minimum number of votes for a decision to be made
-        var REQUIRED_SUPERMAJORITY = 0.65;
-        var GUARANTEED_RESULT = Math.ceil(MIN_VOTES * REQUIRED_SUPERMAJORITY);
-        var MINUTE = 60 * 1000; // (one minute in ms)
-        var POLL_INTERVAL = MINUTE * 3; // how often to check the open PRs (in seconds)
-        var VOTE_POSITIVE = ':+1:';
-        var VOTE_NEGATIVE = ':-1:';
-        var VOTE_MONKEY = [':monkey:', ':monkey_face:', ':hear_no_evil:',':see_no_evil:',':speak_no_evil:'];
+      var MINUTE = 60 * 1000; // One minute in ms.
 
-        var decideVoteResult = function (yeas, nays) {
-            // vote passes if yeas > nays
-            return (yeas / (yeas + nays)) > REQUIRED_SUPERMAJORITY;
-        };
-
-        var voteStartedComment = template.render('voting/voteStarted.md', {
-            jitter: PERIOD_JITTER * 100 / 2,
-            majority: REQUIRED_SUPERMAJORITY * 100,
-            period: PERIOD,
-            min_votes: MIN_VOTES
-        });
-
-        var modifiedWarning = template.render('voting/modifiedWarning.md');
-        var couldntMergeWarning = template.render('voting/couldntMergeWarning.md');
-
-        var kitten = '';
-
-        var votePassComment = template.render('voting/votePassComment.md');
-        var voteFailComment = template.render('voting/voteFailComment.md');
-
-// We add a jitter to the PERIOD after the comment has been created, "to avoid people timing their votes".
-// More precisely, there is an incentive in the previous constant-period system to send in the vote at the last second,
-// because otherwise people can "react" to it by voting in the opposite direction (without sock-puppet accounts).
-        PERIOD = PERIOD * (1 + (Math.random() - 0.5) * PERIOD_JITTER);
-
-        var voteEndComment = function (pass, yea, nay, nonStarGazers) {
-            var total = yea + nay;
-            var yeaPercent = percent(yea / total);
-            var nayPercent = percent(nay / total);
-
-            // Map nonStarGazer user names to an object list that's better
-            // for Mustache template.
-            var nonStarGazerMap = nonStarGazers.map(function (user, index) {
-                return {
-                    name: user,
-                    first: (index === 0),
-                    last: (index === (nonStarGazers.length - 1))
-                };
-            });
-
-            var voteEndedData = {
-                passFail: (pass ? (kitten + votePassComment) : voteFailComment),
-                yea: yea,
-                nay: nay,
-                yeaPercent: yeaPercent,
-                nayPercent: nayPercent,
-                nonStarGazers: nonStarGazerMap
-            };
-
-            updateKittenImage();
-
-            return template.render('voting/voteEnded.md', voteEndedData);
-        };
-
-        var nonStarGazerComment = function (voteCast, body, user) {
-            return (template.render('voting/nonStarGazerVote.md', {
-                user: user,
-                body: body,
-                vote: voteCast,
-                stargazerRefreshInterval: (POLL_INTERVAL / MINUTE) // Use readable interval value
-            }));
-        };
-
-        var votesPerPR = {};
-        var cachedStarGazers = {};
-        var cachedPRs = {};
-
-        function percent(n) {
-            return Math.floor(n * 1000) / 10;
+      function noop(err) {
+        if (err) {
+          console.error(err);
+          console.error(err.stack);
         }
+      }
 
-        function noop(err) {
-            if (err) { console.error(err); }
+
+      var Voting = function Voting(repo, votingConfig) {
+        var self = this;
+
+        this.starGazers = {};
+        this.pullRequests = {};
+        this.startedPRs = {};
+        this.votesPerPR = {};
+
+        this.repo = repo;
+        this.votingConfig = votingConfig;
+        this.votingConfig.truePeriod =
+          this.votingConfig.period * (1 + (Math.random() - 0.5) * votingConfig.period_jitter);
+        this.votingConfig.guaranteedResult =
+          Math.ceil(this.votingConfig.minVotes * this.votingConfig.supermajority);
+        this.voteController = new VoteController(repo, votingConfig, this.starGazers, this.votesPerPR);
+        this.templates = templates(this.votingConfig);
+
+        this.updateStarGazers(this.refreshAllPRs.bind(this));
+
+        // If we're not set up for GitHub Webhooks, poll the server every interval.
+        if (typeof config.githubAuth === 'undefined') {
+          setInterval(this.refreshAllPRs.bind(this), this.votingConfig.pollInterval * MINUTE);
+        } else {
+          // Repoll all PRs every 30 minutes, just to be safe.
+          setInterval(this.refreshAllPRs.bind(this), 30 * MINUTE);
         }
-
-
-        function updateKittenImage() {
-            // get a random kitten to be used by this instance of the bot
-            request('https://thecatapi.com/api/images/get?format=html', function (err, resp, body) {
-                if (err) {
-                    console.error(err);
-                    console.error(err.stack);
-                    return;
-                }
-                kitten = body;
-            });
-        }
-
-        // an index of PRs we have posted a 'vote started' comment on
-        var started = {};
-
-        // handles an open PR
-        function handlePR(pr) {
-            // Don't act on closed PRs
-            if (pr.state === 'closed') {
-                return console.log('Update triggered on closed PR #' + pr.number);
-            }
-
-            // if there is no 'vote started' comment, post one
-            if (!started[pr.number]) {
-                postVoteStarted(pr);
-            }
-
-            // TODO: instead of closing PRs that get changed, just post a warning that
-            //       votes have been reset, and only count votes that happen after the
-            //       last change
-            assertNotModified(pr, function () {
-                processPR(pr);
-            });
-        }
-
-        // posts a comment explaining that the vote has started
-        // (if one isn't already posted)
-        function postVoteStarted(pr) {
-            getVoteStartedComment(pr, function (err, comment) {
-                if (err) { return console.error('error in postVoteStarted:', err); }
-                if (comment) {
-                    // we already posted the comment
-                    started[pr.number] = true;
-                    return;
-                }
-
-                gh.issues.createComment({
-                    user: config.user,
-                    repo: config.repo,
-                    number: pr.number,
-                    body: voteStartedComment + " " + pr.head.sha
-
-                }, function (err) {
-                    if (err) { return console.error('error in postVoteStarted:', err); }
-
-                    events.emit('bot.pull_request.vote_started', pr);
-                    started[pr.number] = true;
-                    console.log('Posted a "vote started" comment for PR #' + pr.number);
-
-                    // determine whether I like this PR or not
-                    var score = sentiment(pr.title + ' ' + pr.body).score;
-                    if (score > 1) {
-                        // I like this PR, let's vote for it!
-                        gh.issues.createComment({
-                            user: config.user,
-                            repo: config.repo,
-                            number: pr.number,
-                            body: VOTE_POSITIVE
-                        });
-                    } else if (score < -1) {
-                        // Ugh, this PR sucks, boooo!
-                        gh.issues.createComment({
-                            user: config.user,
-                            repo: config.repo,
-                            number: pr.number,
-                            body: VOTE_NEGATIVE
-                        });
-                    } // otherwise it's meh, so I don't care
-                });
-            });
-        }
-
-        // checks for a "vote started" comment posted by ourself
-        // returns the comment if found
-        function getVoteStartedComment(pr, cb) {
-            for (var i = 0; i < pr.comments.length; i++) {
-                var postedByMe = pr.comments[i].user.login === config.user;
-                var isVoteStarted = pr.comments[i].body.indexOf(voteStartedComment) === 0;
-                if (postedByMe && isVoteStarted) {
-                    // comment was found
-                    return cb(null, pr.comments[i]);
-                }
-            }
-
-            // comment wasn't found
-            return cb(null, null);
-        }
-
-        // calls cb if the PR has not been committed to since the voting started,
-        // otherwise displays an error
-        function assertNotModified(pr, cb) {
-            getVoteStartedComment(pr, function (err, comment) {
-                if (err) { return console.error('error in assertNotModified:', err); }
-
-                if (comment) {
-                    var originalHead = comment.body.substr(comment.body.lastIndexOf(' ') + 1);
-                    if (pr.head.sha !== originalHead) {
-                        console.log('Posting a "modified PR" warning, and closing #' + pr.number);
-                        return closePR(modifiedWarning, pr, noop);
-                    }
-                }
-
-                cb();
-            });
-        }
-
-        // returns an object of all the people who have starred the repo, indexed by username
-        function getStargazerIndex(cb) {
-            getAllPages(gh.repos.getStargazers, function (err, stargazers) {
-                if (err || !stargazers) {
-                    console.error('Error getting stargazers:', err);
-                    if (typeof cb === 'function') {
-                        return cb(err, stargazers);
-                    }
-                    return;
-                }
-
-                var index = {};
-                stargazers.forEach(function (stargazer) {
-                    index[stargazer.login] = true;
-                });
-                cachedStarGazers = index;
-                if (typeof cb === 'function') {
-                    cb(stargazers);
-                }
-            });
-        }
-
-        // returns all results of a paginated function
-        function getAllPages(pr, f, cb, n, results) {
-            // pr is optional
-            if (typeof pr === 'function') {
-                cb = f;
-                f = pr;
-                pr = null;
-            }
-            if (!results) { results = []; }
-            if (!n) { n = 0; }
-
-            f({
-                user: config.user,
-                repo: config.repo,
-                number: pr ? pr.number : null,
-                page: n,
-                per_page: 100
-
-            }, function (err, res) {
-                if (err || !res) { return cb(err); }
-
-                results = results.concat(res);
-
-                // if we got to the end of the results, return them
-                if (res.length < 100) {
-                    return cb(null, results);
-                }
-
-                // otherwise keep getting more pages recursively
-                getAllPages(pr, f, cb, n + 1, results);
-            });
-        }
-
-        // closes the PR. if `message` is provided, it will be posted as a comment
-        function closePR(message, pr, cb) {
-            // message is optional
-            if (typeof pr === 'function') {
-                cb = pr;
-                pr = message;
-                message = '';
-            }
-
-            // Flag the PR as closed pre-emptively to prevent multiple comments.
-            cachedPRs[pr.number].state = 'closed';
-
-            if (message) {
-                gh.issues.createComment({
-                    user: config.user,
-                    repo: config.repo,
-                    number: pr.number,
-                    body: message
-                }, noop);
-            }
-
-            gh.pullRequests.update({
-                user: config.user,
-                repo: config.repo,
-                number: pr.number,
-                state: 'closed',
-                title: pr.title,
-                body: pr.body
-
-            }, function (err, res) {
-                if (err) { return cb(err); }
-                console.log('Closed PR #' + pr.number);
-                return cb(null, res);
-            });
-        }
-
-        // merges a PR into master. If it can't be merged, a warning is posted and the PR is closed.
-        function mergePR(pr, cb) {
-            gh.pullRequests.get({
-                user: config.user,
-                repo: config.repo,
-                number: pr.number
-
-            }, function (err, res) {
-                if (err || !res) { return cb(err); }
-                if (res.mergeable === false) {
-                    console.error('Attempted to merge PR #' + res.number +
-                    ' but it failed with a mergeable (' + res.mergeable +
-                    ') state of ' + res.mergeable_state);
-                    return closePR(couldntMergeWarning, pr, function () {
-                        cb(new Error('Could not merge PR.'));
-                    });
-                } else if (res.mergeable === null) {
-                    console.error('Attempted to merge PR #' + res.number +
-                    ' but it was postponed with a mergeable (' +
-                    res.mergeable + ') state of ' + res.mergeable_state);
-                    // Try it again in 5 seconds if it failed with a "null" mergeable state.
-                    return setTimeout(function () {
-                        mergePR(pr, cb);
-                    }, 5000);
-                }
-
-                // Flag the PR as closed pre-emptively to prevent multiple comments.
-                cachedPRs[pr.number].state = 'closed';
-
-                gh.pullRequests.merge({
-                    user: config.user,
-                    repo: config.repo,
-                    number: pr.number
-                }, cb);
-            });
-        }
-
-        /**
-         * Fetch all PRs from GitHub, and then look up all of their comments.
-         */
-        function refreshAllPRs() {
-            getAllPages(gh.pullRequests.getAll, function (err, prs) {
-                if (err || !prs) {
-                    return console.error('Error getting Pull Requests.', err);
-                }
-
-                prs.map(function (pr) {
-                    pr.comments = [];
-                    cachedPRs[pr.number] = pr;
-                    refreshAllComments(pr, handlePR);
-                });
-            });
-        }
-
-        /**
-         * Fetch all comments for a PR from GitHub.
-         */
-        function refreshAllComments(pr, cb) {
-            getAllPages(pr, gh.issues.getComments, function (err, comments) {
-                if (err || !comments) {
-                    return console.error('Error getting Comments.', err);
-                }
-
-                pr.comments = comments;
-                if (typeof cb === 'function') {
-                    cb(pr);
-                }
-            });
-        }
-
-        /**
-         * Tally all of the votes for a PR, and if conditions pass, merge or close it.
-         */
-        function processPR(pr, cb) {
-            if (typeof cb === 'undefined') { cb = noop; }
-
-            var voteResults = tallyVotes(pr);
-
-            // only make a decision if the minimum period has elapsed.
-            var age = Date.now() - new Date(pr.created_at).getTime();
-            if (age / MINUTE < PERIOD) { return cb(null, false); }
-
-            var highestVote = Math.max(voteResults.positive, voteResults.negative);
-
-            // only make a decision if we have the minimum amount of votes
-            if (highestVote < GUARANTEED_RESULT) { return cb(null, false); }
-
-            // vote passes if yeas > nays
-            var passes = decideVoteResult(voteResults.positive, voteResults.negative);
-
-            gh.issues.createComment({
-                user: config.user,
-                repo: config.repo,
-                number: pr.number,
-                body: voteEndComment(passes, voteResults.positive, voteResults.negative, voteResults.nonStarGazers)
-            }, noop);
-
-            // Post in IRC
-            if (passes) {
-                mergePR(pr, cb);
-            } else {
-                closePR(pr, cb);
-            }
-        }
-
-        /**
-         * Tally up the votes on a PR, and monitor which users are stargazers.
-         */
-        function tallyVotes(pr) {
-            var tally = pr.comments.reduce(function (result, comment) {
-                var user = comment.user.login,
-                    body = comment.body,
-                    voteCast = calculateUserVote(body);
-
-                // People that don't star the repo cannot vote.
-                if (!cachedStarGazers[user]) {
-                    if (result.nonStarGazers.indexOf(user) === -1) {
-                        result.nonStarGazers.push(user);
-                    }
-
-                    if (voteCast !== VOTE_MONKEY && voteCast !== null) {
-                        // This comment has not yet been marked as a monkey, but should be.
-                        // The user is not a stargazer, but has made a vote-style comment.
-                        // Edit the comment with a monkey warning appended to the end.
-                        gh.issues.editComment({
-                            user: config.user,
-                            repo: config.repo,
-                            id: comment.id,
-                            body: nonStarGazerComment(voteCast, body, user)
-                        }, noop);
-                    }
-                    return result;
-                }
-
-                // Only record votes that are explicitly
-                // positive, or negative.
-                // Monkeys and votes that go both ways
-                // do not record a result.
-                if (voteCast === VOTE_POSITIVE) {
-                    result.votes[user] = true;
-                }
-
-                if (voteCast === VOTE_NEGATIVE) {
-                    result.votes[user] = false;
-                }
-
-                return result;
-            }, {
-                votes: {},
-                nonStarGazers: [],
-            });
-
-            // Add the PR author as a positive vote by default.
-            if (!(pr.user.login in tally.votes)) {
-                tally.votes[pr.user.login] = true;
-            }
-
-            var tallySpread = Object.keys(tally.votes).reduce(function (result, user) {
-                // Increment the positive/negative counters.
-                if (tally.votes[user]) {
-                    result.positive++;
-                } else {
-                    result.negative++;
-                }
-
-                result.total++;
-                return result;
-            }, {
-                positive: 0,
-                negative: 0,
-                total: 0
-            });
-
-            tallySpread.percentPositive = percent(tallySpread.positive / tallySpread.total);
-            tallySpread.percentNegative = percent(tallySpread.negative / tallySpread.total);
-
-            _.merge(tally, tallySpread);
-
-            // Store this so that we can eventually make a votes webserver endpoint.
-            votesPerPR[pr.number] = { pr: pr, votes: tally };
-            events.emit('bot.pull_request.votes', pr, tally);
-
-            return tally;
-        }
-
-        // Returns true if the text contains a positive vote
-        function isPositive (text) {
-            return (text.indexOf(VOTE_POSITIVE) !== -1);
-        }
-
-        // Returns true if the text contains a negative vote
-        function isNegative (text) {
-            return (text.indexOf(VOTE_NEGATIVE) !== -1);
-        }
-
-        // Returns true if the text is a monkey vote.
-        function isMonkey (text) {
-            // VOTE_MONKEY is an array of monkey vote keys.
-            // If any of those keys appears in the text, the
-            // vote is a monkey.
-            return VOTE_MONKEY.some(function (monkey) {
-                return (text.indexOf(monkey) !== -1);
-            });
-        }
-
-        /**
-         * Check the text of a comment, and determine what vote was cast.
-         */
-        function calculateUserVote(text) {
-            var positive = isPositive(text),
-                negative = isNegative(text),
-                monkey = isMonkey(text);
-
-            if (monkey) {
-                return VOTE_MONKEY;
-            }
-
-            // If the user has voted positive and negative, or hasn't voted, ignore it.
-            if (positive && negative) {
-                return null;
-            }
-            if (!positive && !negative) {
-                return null;
-            }
-
-            // If positive is true, its positive. If its false, they voted negative.
-            if (positive) {
-                return VOTE_POSITIVE;
-            }
-
-            return VOTE_NEGATIVE;
-        }
+        // Check the stargazers every interval.
+        setInterval(this.updateStarGazers.bind(this), this.votingConfig.pollInterval * MINUTE);
 
         /**
          * When a pull request is opened, add it to the cache and handle it.
          */
         events.on('github.pull_request.opened', function (data) {
-            data.pull_request.comments = [];
-            cachedPRs[data.number] = data.pull_request;
-            handlePR(data.pull_request);
+          data.pull_request.comments = [];
+          self.pullRequests[data.number] = data.pull_request;
+          self.handlePR(data.pull_request);
         });
 
         /**
          * When a pull request is closed, mark it so we don't process it again.
          */
         events.on('github.pull_request.closed', function (data) {
-            // Remove this PR from votesPerPR so it no longer shows up on website.
-            delete votesPerPR[data.number];
+          // Remove this PR from votesPerPR so it no longer shows up on website.
+          delete self.votesPerPR[data.number];
 
-            var pr = cachedPRs[data.number];
-            if (typeof pr !== 'undefined') {
-                pr.state = 'closed';
-            }
+          var pr = self.pullRequests[data.number];
+          if (typeof pr !== 'undefined') {
+            pr.state = 'closed';
+          }
         });
 
         /**
          * When a comment is created, push it onto the PR, and handle the PR again.
          */
         events.on('github.comment.created', function (data) {
-            var pr = cachedPRs[data.issue.number];
-            if (typeof pr === 'undefined') {
-                return console.error('Could not find PR', data.issue.number, 'when adding a comment');
-            }
-            pr.comments.push(data.comment);
-            handlePR(pr);
+          var pr = self.pullRequests[data.issue.number];
+          if (typeof pr === 'undefined') {
+            return console.error('Could not find PR', data.issue.number, 'when adding a comment');
+          }
+          pr.comments.push(data.comment);
+          self.handlePR(pr);
         });
+      };
 
-        var voting = {};
+      /**
+       * Update the StarGazer cache.
+       */
+      Voting.prototype.updateStarGazers = function updateStarGazers(cb) {
+        var self = this;
 
-        /**
-         * Initialize the voting system by polling stargazers, and then fetching PRs.
-         */
-        voting.initialize = function () {
-            updateKittenImage();
-            getStargazerIndex(refreshAllPRs);
-
-            // If we're not set up for GitHub Webhooks, poll the server every interval.
-            if (typeof config.githubAuth === 'undefined') {
-                setInterval(refreshAllPRs, POLL_INTERVAL);
-            } else {
-                // Repoll all PRs every 30 minutes, just to be safe.
-                setInterval(refreshAllPRs, MINUTE * 30);
+        gh.getAllPages(this.repo, gh.repos.getStargazers, function (err, stargazers) {
+          if (err || !stargazers) {
+            console.error('Error getting stargazers:', err);
+            if (typeof cb === 'function') {
+              return cb(err, stargazers);
             }
-            // Check the stargazers every interval.
-            setInterval(getStargazerIndex, POLL_INTERVAL);
-        };
+            return;
+          }
 
-        voting.testing = {
-            processPR: processPR,
-            cachedStarGazers: cachedStarGazers,
-            cachedPRs: cachedPRs,
-            voteEndComment: voteEndComment
-        };
+          var index = {};
+          stargazers.forEach(function (stargazer) {
+            index[stargazer.login] = true;
+          });
+          self.starGazers = index;
+          console.log('Got stargazers for ' + self.repo.user + '/' + self.repo.repo);
+          if (typeof cb === 'function') {
+            cb(stargazers);
+          }
+        });
+      };
 
-        voting.currentVotes = votesPerPR;
-        voting.minVotes = MIN_VOTES;
-        voting.period = PERIOD;
-        voting.supermajority = REQUIRED_SUPERMAJORITY;
-        voting.guaranteedResult = GUARANTEED_RESULT;
+      /**
+       * Fetch all PRs from GitHub, and then look up all of their comments.
+       */
+      Voting.prototype.refreshAllPRs = function refreshAllPRs() {
+        var self = this;
 
-        module.exports = voting;
+        gh.getAllPages(this.repo, gh.pullRequests.getAll, function (err, prs) {
+          if (err || !prs) {
+            return console.error('Error getting Pull Requests.', err);
+          }
+
+          prs.map(function (pr) {
+            pr.comments = [];
+            self.pullRequests[pr.number] = pr;
+            self.refreshAllComments(pr, self.handlePR.bind(self));
+          });
+        });
+      };
+
+      /**
+       * Fetch all comments for a PR from GitHub.
+       */
+      Voting.prototype.refreshAllComments = function refreshAllComments(pr, cb) {
+        var self = this;
+        var prRequest = _.merge({}, this.repo, { number: pr.number });
+
+        gh.getAllPages(prRequest, gh.issues.getComments, function (err, comments) {
+          if (err || !comments) {
+            return console.error('Error getting Comments.', err);
+          }
+
+          pr.comments = comments;
+          console.log('Got comments for ' + self.repo.user + '/' + self.repo.repo);
+          if (typeof cb === 'function') {
+            cb(pr);
+          }
+        });
+      };
+
+      Voting.prototype.handlePR = function handlePR(pr) {
+        var self = this;
+
+        // Don't act on closed PRs
+        if (pr.state === 'closed') {
+          return console.log('Update triggered on closed PR #' + pr.number);
+        }
+
+        // if there is no 'vote started' comment, post one
+        if (!this.startedPRs[pr.number]) {
+          this.postVoteStarted(pr);
+        }
+
+        // TODO: instead of closing PRs that get changed, just post a warning that
+        //     votes have been reset, and only count votes that happen after the
+        //     last change
+        this.assertNotModified(pr, function () {
+          self.processPR(pr);
+        });
+      };
+
+      Voting.prototype.postVoteStarted = function postVoteStarted(pr) {
+        var self = this;
+
+        this.getVoteStartedComment(pr, function (err, comment) {
+          if (err) { return console.error('error in postVoteStarted:', err); }
+          if (comment) {
+            // we already posted the comment
+            self.startedPRs[pr.number] = true;
+            return;
+          }
+
+          gh.issues.createComment({
+            user: self.repo.user,
+            repo: self.repo.repo,
+            number: pr.number,
+            body: self.templates.voteStartedComment + " " + pr.head.sha
+
+          }, function (err) {
+            if (err) { return console.error('error in postVoteStarted:', err); }
+
+            events.emit('bot.pull_request.vote_started', pr);
+            self.startedPRs[pr.number] = true;
+            console.log('Posted a "vote started" comment for PR #' + pr.number);
+
+            // determine whether I like this PR or not
+            var score = sentiment(pr.title + ' ' + pr.body).score;
+            if (score > 1) {
+              // I like this PR, let's vote for it!
+              gh.issues.createComment({
+                user: self.repo.user,
+                repo: self.repo.repo,
+                number: pr.number,
+                body: VOTE_POSITIVE
+              });
+            } else if (score < -1) {
+              // Ugh, this PR sucks, boooo!
+              gh.issues.createComment({
+                user: self.repo.user,
+                repo: self.repo.repo,
+                number: pr.number,
+                body: VOTE_NEGATIVE
+              });
+            } // otherwise it's meh, so I don't care
+          });
+        });
+      };
+
+      /**
+       * Check for a "vote started" comment posted by ourself.
+       *
+       * @return (object|null)
+       *   Return the comment if found, and null otherwise.
+       */
+      Voting.prototype.getVoteStartedComment  = function getVoteStartedComment(pr, cb) {
+        for (var i = 0; i < pr.comments.length; i++) {
+          var postedByMe = pr.comments[i].user.login === this.repo.user;
+          var isVoteStarted = pr.comments[i].body.indexOf(this.templates.voteStartedComment) === 0;
+          if (postedByMe && isVoteStarted) {
+            // comment was found
+            return cb(null, pr.comments[i]);
+          }
+        }
+
+        // comment wasn't found
+        return cb(null, null);
+      };
+
+      /**
+       * If the PR has not been modified, call the cb, otherwise display an error.
+       */
+      Voting.prototype.assertNotModified = function assertNotModified(pr, cb) {
+        var self = this;
+
+        this.getVoteStartedComment(pr, function (err, comment) {
+          if (err) { return console.error('error in assertNotModified:', err); }
+
+          if (comment) {
+            var originalHead = comment.body.substr(comment.body.lastIndexOf(' ') + 1);
+            if (pr.head.sha !== originalHead) {
+              console.log('Posting a "modified PR" warning, and closing #' + pr.number);
+              return self.closePR(modifiedWarning, pr, noop);
+            }
+          }
+
+          cb();
+        });
+      };
+
+      /**
+       * Tally all of the votes for a PR, and if conditions pass, merge or close it.
+       */
+      Voting.prototype.processPR = function processPR(pr, cb) {
+        var self = this;
+
+        if (typeof cb === 'undefined') { cb = noop; }
+
+        var voteResults = this.voteController.tallyVotes(pr);
+
+        // only make a decision if the minimum period has elapsed.
+        var age = Date.now() - new Date(pr.created_at).getTime();
+        if (age / MINUTE < this.votingConfig.truePeriod) { return cb(null, false); }
+
+        var highestVote = Math.max(voteResults.positive, voteResults.negative);
+
+        // only make a decision if we have the minimum amount of votes
+        if (highestVote < this.votingConfig.guaranteedResult) { return cb(null, false); }
+
+        // vote passes if yeas > nays
+        var passes = this.voteController.doesVotePass(voteResults.positive, voteResults.negative);
+
+        gh.issues.createComment({
+          user: self.repo.user,
+          repo: self.repo.repo,
+          number: pr.number,
+          body: this.templates.voteEndComment(passes, voteResults.positive, voteResults.negative, voteResults.nonStarGazers)
+        }, noop);
+
+        // Post in IRC
+        if (passes) {
+          this.mergePR(pr, cb);
+        } else {
+          this.closePR(pr, cb);
+        }
+      };
+
+      // closes the PR. if `message` is provided, it will be posted as a comment
+      Voting.prototype.closePR = function closePR(message, pr, cb) {
+        var self = this;
+
+        // message is optional
+        if (typeof pr === 'function') {
+          cb = pr;
+          pr = message;
+          message = '';
+        }
+
+        // Flag the PR as closed pre-emptively to prevent multiple comments.
+        this.pullRequests[pr.number].state = 'closed';
+
+        if (message) {
+          gh.issues.createComment({
+            user: self.repo.user,
+            repo: self.repo.repo,
+            number: pr.number,
+            body: message
+          }, noop);
+        }
+
+        gh.pullRequests.update({
+          user: self.repo.user,
+          repo: self.repo.repo,
+          number: pr.number,
+          state: 'closed',
+          title: pr.title,
+          body: pr.body
+
+        }, function (err, res) {
+          if (err) { return cb(err); }
+          console.log('Closed PR #' + pr.number);
+          return cb(null, res);
+        });
+      };
+
+      // merges a PR into master. If it can't be merged, a warning is posted and the PR is closed.
+      Voting.prototype.mergePR = function mergePR(pr, cb) {
+        var self = this;
+
+        gh.pullRequests.get({
+          user: self.repo.user,
+          repo: self.repo.repo,
+          number: pr.number
+
+        }, function (err, res) {
+          if (err || !res) { return cb(err); }
+          if (res.mergeable === false) {
+            console.error('Attempted to merge PR #' + res.number +
+            ' but it failed with a mergeable (' + res.mergeable +
+            ') state of ' + res.mergeable_state);
+            return closePR(couldntMergeWarning, pr, function () {
+              cb(new Error('Could not merge PR.'));
+            });
+          } else if (res.mergeable === null) {
+            console.error('Attempted to merge PR #' + res.number +
+            ' but it was postponed with a mergeable (' +
+            res.mergeable + ') state of ' + res.mergeable_state);
+            // Try it again in 5 seconds if it failed with a "null" mergeable state.
+            return setTimeout(function () {
+              self.mergePR(pr, cb);
+            }, 5000);
+          }
+
+          // Flag the PR as closed pre-emptively to prevent multiple comments.
+          self.pullRequests[pr.number].state = 'closed';
+
+          gh.pullRequests.merge({
+            user: self.repo.user,
+            repo: self.repo.repo,
+            number: pr.number
+          }, cb);
+        });
+      };
+
+
+
+      module.exports = Voting;
     });
 }());

--- a/lib/voting/voting.js
+++ b/lib/voting/voting.js
@@ -252,7 +252,7 @@
                 user: self.repo.user,
                 repo: self.repo.repo,
                 number: pr.number,
-                body: VOTE_POSITIVE
+                body: self.voteController.votePositive,
               });
             } else if (score < -1) {
               // Ugh, this PR sucks, boooo!
@@ -260,7 +260,7 @@
                 user: self.repo.user,
                 repo: self.repo.repo,
                 number: pr.number,
-                body: VOTE_NEGATIVE
+                body: self.voteController.voteNegative,
               });
             } // otherwise it's meh, so I don't care
           });

--- a/main.js
+++ b/main.js
@@ -7,6 +7,7 @@
         'lodash',
 
         './config.loader',
+        './lib/repositories.js',
         './lib/events.js',
         './lib/github.js',
         './lib/integrations',
@@ -23,6 +24,7 @@
         _,
 
         config,
+        repositories,
         events,
         gh,
         integrations,
@@ -94,24 +96,9 @@
             //talk.speak();
 
             // Allow the voting system to bootstrap and begin monitoring PRs.
-            new voting({
-              repo: config.repo,
-              user: config.user,
-            }, config.voting);
-
-            if (typeof config.additionalRepos !== 'undefined') {
-              config.additionalRepos.forEach(function (repo) {
-                var votingConfig = _.merge({}, config.voting);
-                // Merge in repo-specific voting configurations.
-                if (typeof repo.voting !== 'undefined') {
-                  _.merge(votingConfig, repo.voting);
-                }
-                new voting({
-                  repo: repo.repo,
-                  user: repo.user,
-                }, votingConfig);
-              });
-            }
+            repositories.forEach(function (repo) {
+                new voting(repo);
+            });
         }
 
         function main() {

--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@
     var deps = [
         'child_process',
         'gift',
+        'lodash',
 
         './config.loader',
         './lib/events.js',
@@ -19,6 +20,7 @@
     define(deps, function(
         Spawn,
         git,
+        _,
 
         config,
         events,
@@ -84,10 +86,27 @@
             considerExistence();
 
             // greet the other bots
-            talk.speak();
+            //talk.speak();
 
             // Allow the voting system to bootstrap and begin monitoring PRs.
-            voting.initialize();
+            new voting({
+              repo: config.repo,
+              user: config.user,
+            }, config.voting);
+
+            if (typeof config.additionalRepos !== 'undefined') {
+              config.additionalRepos.forEach(function (repo) {
+                var votingConfig = _.merge({}, config.voting);
+                // Merge in repo-specific voting configurations.
+                if (typeof repo.voting !== 'undefined') {
+                  _.merge(votingConfig, repo.voting);
+                }
+                new voting({
+                  repo: repo.repo,
+                  user: repo.user,
+                }, votingConfig);
+              });
+            }
         }
 
         function main() {

--- a/main.js
+++ b/main.js
@@ -93,7 +93,7 @@
             considerExistence();
 
             // greet the other bots
-            //talk.speak();
+            talk.speak();
 
             // Allow the voting system to bootstrap and begin monitoring PRs.
             repositories.forEach(voting.setup);

--- a/main.js
+++ b/main.js
@@ -41,7 +41,12 @@
         }
 
         // if we merge something, `git sync` the changes and start the new version
-        events.on('github.pull_request.merged', function () {
+        events.on('github.pull_request.merged', function (data) {
+            // Only trigger a restart if this is for the bot's repository.
+            if (data.repository.name !== config.repo || data.repository.owner.login !== config.user) {
+                return;
+            }
+
             sync(function (err) {
                 if (err) { return console.error('error pulling from origin/master:', err); }
 

--- a/main.js
+++ b/main.js
@@ -96,9 +96,7 @@
             //talk.speak();
 
             // Allow the voting system to bootstrap and begin monitoring PRs.
-            repositories.forEach(function (repo) {
-                new voting(repo);
-            });
+            repositories.forEach(voting.setup);
         }
 
         function main() {

--- a/tests/unit/voting.js
+++ b/tests/unit/voting.js
@@ -8,12 +8,13 @@
     'lodash',
     'nock',
 
+    '../../config.js',
     '../mocks/github',
     '../mocks/thecatapi',
     '../../lib/voting',
   ];
 
-  define(deps, function (assert, _, nock, mock, mockingCat, voting) {
+  define(deps, function (assert, _, nock, config, mock, mockingCat, voting) {
     describe('voting', function () {
       var basePR = {
         number: 1,
@@ -58,6 +59,13 @@
         });
         voting.testing.cachedStarGazers[basePR.user.login] = true;
       }
+
+      beforeEach(function () {
+        voting.testing.setRepo({
+          user: config.user,
+          repo: config.repo,
+        });
+      });
 
       afterEach(function () {
         resetStargazers();

--- a/tests/unit/voting.js
+++ b/tests/unit/voting.js
@@ -14,7 +14,7 @@
     '../../lib/voting',
   ];
 
-  define(deps, function (assert, _, nock, config, mock, mockingCat, voting) {
+  define(deps, function (assert, _, nock, config, mock, mockingCat, Voting) {
     describe('voting', function () {
       var basePR = {
         number: 1,
@@ -28,6 +28,8 @@
         state: 'open',
         mergeable: true,
       };
+
+      var voting;
 
       function addComments(pr, positive, negative) {
         var i;
@@ -54,17 +56,17 @@
       }
 
       function resetStargazers() {
-        Object.keys(voting.testing.cachedStarGazers).forEach(function (name) {
-          delete voting.testing.cachedStarGazers[name];
+        Object.keys(voting.starGazers).forEach(function (name) {
+          delete voting.starGazers[name];
         });
-        voting.testing.cachedStarGazers[basePR.user.login] = true;
+        voting.starGazers[basePR.user.login] = true;
       }
 
       beforeEach(function () {
-        voting.testing.setRepo({
+        voting = new Voting({
           user: config.user,
           repo: config.repo,
-        });
+        }, config.voting);
       });
 
       afterEach(function () {
@@ -76,7 +78,7 @@
         var testPR = _.merge({}, basePR);
         testPR.created_at = Date.now();
 
-        voting.testing.processPR(testPR, function (err, res) {
+        voting.processPR(testPR, function (err, res) {
           assert.strictEqual(res, false, 'Did not cancel processing of PR');
           done();
         });
@@ -86,10 +88,10 @@
         var testPR = _.merge({}, basePR);
         addComments(testPR, 3, 0);
         getVoters(testPR).forEach(function (user) {
-          voting.testing.cachedStarGazers[user] = true;
+          voting.starGazers[user] = true;
         });
 
-        voting.testing.processPR(testPR, function (err, res) {
+        voting.processPR(testPR, function (err, res) {
           assert.strictEqual(res, false, 'Did not cancel processing of PR');
           done();
         });
@@ -100,10 +102,10 @@
         var testPR = _.merge({}, basePR);
         addComments(testPR, 3, 0);
         getVoters(testPR).slice(0, -1).forEach(function (user) {
-          voting.testing.cachedStarGazers[user] = true;
+          voting.starGazers[user] = true;
         });
 
-        var result = voting.testing.processPR(testPR, function (err, res) {
+        var result = voting.processPR(testPR, function (err, res) {
           if (err) { throw err; }
           mockEditComment.done();
           done();
@@ -116,14 +118,14 @@
         var mockCreateComment = mock.issues.createComment();
         var mockCat = mockingCat();
         var testPR = _.merge({}, basePR);
-        voting.testing.cachedPRs[testPR.number] = testPR;
+        voting.pullRequests[testPR.number] = testPR;
         // One less since the ticket creator is already counted.
-        addComments(testPR, voting.minVotes - 1, 0);
+        addComments(testPR, voting.votingConfig.minVotes - 1, 0);
         getVoters(testPR).forEach(function (user) {
-          voting.testing.cachedStarGazers[user] = true;
+          voting.starGazers[user] = true;
         });
 
-        var result = voting.testing.processPR(testPR, function (err, res) {
+        var result = voting.processPR(testPR, function (err, res) {
           if (err) { throw err; }
           mockCreateComment.done();
           mockPRGet.done();
@@ -135,17 +137,17 @@
 
       it('should close failed PRs', function (done) {
         var testPR = _.merge({}, basePR);
-        voting.testing.cachedPRs[testPR.number] = testPR;
-        addComments(testPR, 0, voting.minVotes);
+        voting.pullRequests[testPR.number] = testPR;
+        addComments(testPR, 0, voting.votingConfig.minVotes);
         getVoters(testPR).forEach(function (user) {
-          voting.testing.cachedStarGazers[user] = true;
+          voting.starGazers[user] = true;
         });
 
         var mockPRClose = mock.pullRequests.close(testPR);
         var mockCreateComment = mock.issues.createComment();
         var mockCat = mockingCat();
 
-        var result = voting.testing.processPR(testPR, function (err, res) {
+        var result = voting.processPR(testPR, function (err, res) {
           if (err) { throw err; }
           mockCreateComment.done();
           mockPRClose.done();
@@ -160,14 +162,14 @@
         var mockCreateComment = mock.issues.createComment();
         var mockCat = mockingCat();
         var testPR = _.merge({}, basePR);
-        voting.testing.cachedPRs[testPR.number] = testPR;
+        voting.pullRequests[testPR.number] = testPR;
         // One less since the ticket creator is already counted.
-        addComments(testPR, voting.guaranteedResult - 1, 0);
+        addComments(testPR, voting.votingConfig.guaranteedResult - 1, 0);
         getVoters(testPR).forEach(function (user) {
-          voting.testing.cachedStarGazers[user] = true;
+          voting.starGazers[user] = true;
         });
 
-        var result = voting.testing.processPR(testPR, function (err, res) {
+        var result = voting.processPR(testPR, function (err, res) {
           if (err) { throw err; }
           mockCreateComment.done();
           mockPRGet.done();
@@ -179,17 +181,17 @@
 
       it("should close a PR that has a guaranteed lose after the time limit", function (done) {
         var testPR = _.merge({}, basePR);
-        voting.testing.cachedPRs[testPR.number] = testPR;
-        addComments(testPR, 0, voting.guaranteedResult);
+        voting.pullRequests[testPR.number] = testPR;
+        addComments(testPR, 0, voting.votingConfig.guaranteedResult);
         getVoters(testPR).forEach(function (user) {
-          voting.testing.cachedStarGazers[user] = true;
+          voting.starGazers[user] = true;
         });
 
         var mockPRClose = mock.pullRequests.close(testPR);
         var mockCreateComment = mock.issues.createComment();
         var mockCat = mockingCat();
 
-        var result = voting.testing.processPR(testPR, function (err, res) {
+        var result = voting.processPR(testPR, function (err, res) {
           if (err) { throw err; }
           mockCreateComment.done();
           mockPRClose.done();
@@ -202,14 +204,14 @@
         var testPR = _.merge({}, basePR);
         // Ten minutes ago
         testPR.created_at = Date.now() - 1000 * 60 * 10;
-        voting.testing.cachedPRs[testPR.number] = testPR;
+        voting.pullRequests[testPR.number] = testPR;
         // One less since the ticket creator is already counted.
-        addComments(testPR, voting.guaranteedResult - 1, 0);
+        addComments(testPR, voting.votingConfig.guaranteedResult - 1, 0);
         getVoters(testPR).forEach(function (user) {
-          voting.testing.cachedStarGazers[user] = true;
+          voting.starGazers[user] = true;
         });
 
-        voting.testing.processPR(testPR, function (err, res) {
+        voting.processPR(testPR, function (err, res) {
           assert.strictEqual(res, false, 'Did not cancel processing of PR');
           done();
         });

--- a/tests/unit/voting.js
+++ b/tests/unit/voting.js
@@ -66,7 +66,8 @@
         voting = new Voting({
           user: config.user,
           repo: config.repo,
-        }, config.voting);
+          votingConfig: config.voting,
+        });
       });
 
       afterEach(function () {

--- a/tests/unit/voting.js
+++ b/tests/unit/voting.js
@@ -11,7 +11,7 @@
     '../../config.js',
     '../mocks/github',
     '../mocks/thecatapi',
-    '../../lib/voting',
+    '../../lib/voting/voting.js',
   ];
 
   define(deps, function (assert, _, nock, config, mock, mockingCat, Voting) {


### PR DESCRIPTION
This is a huge refactor of the voting module, that splits it into three pieces:
* Voting Logic and event handler
* Vote Counter
* Voting Templates

It also adds in support for the bot managing voting on multiple repositories, which paves the way to split the UI into a separate repository, or add any related but non-core functionality into a separate repository if we wish.

Voting config has been moved into the configs, and can be overridden on a per-repository basis (UI could require 10 votes, instead of 8 if we wanted).

All tests should be passing, and I've run through as much of the functionality as is possible to ensure nothing is broken, but I'd appreciate some extra testruns just to be safe.