### PR TITLE
Switch to #anythingbot, where we can give the bot op status in IRC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ node_js:
 after_success: ./node_modules/.bin/coveralls --verbose < coverage/lcov.info
 
 notifications:
-  irc: "chat.freenode.net#botwillacceptanything"
+  irc: "chat.freenode.net#anythingbot"

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ A bot will automatically merge any PR on this repo that gets enough votes from t
 
 ## Contributing
 
-Anyone can create a pull request, and it is greatly appreciated by the community. In order for a pull request to be accepted, the bot has requested that it meets the criteria in its [Definition of Done](https://github.com/botwillacceptanything/botwillacceptanything/blob/master/DoD.md). If you're looking for ideas, please look at [ideas.md](https://github.com/botwillacceptanything/botwillacceptanything/blob/master/ideas.md), and join us in our [IRC](http://kiwiirc.com/client/irc.freenode.net/botwillacceptanything) for ideas or advice on how to implement something.
+Anyone can create a pull request, and it is greatly appreciated by the community. In order for a pull request to be accepted, the bot has requested that it meets the criteria in its [Definition of Done](https://github.com/botwillacceptanything/botwillacceptanything/blob/master/DoD.md). If you're looking for ideas, please look at [ideas.md](https://github.com/botwillacceptanything/botwillacceptanything/blob/master/ideas.md), and join us in our [IRC](http://kiwiirc.com/client/irc.freenode.net/anythingbot) for ideas or advice on how to implement something.
 
 ## Community
 
-[![Visit our IRC channel](https://kiwiirc.com/buttons/irc.freenode.net/botwillacceptanything.png)](https://kiwiirc.com/client/irc.freenode.net/#botwillacceptanything)
+[![Visit our IRC channel](https://kiwiirc.com/buttons/irc.freenode.net/anythingbot.png)](https://kiwiirc.com/client/irc.freenode.net/#anythingbot)
 
 The bot is [**@anythingbot** on Twitter.](https://twitter.com/anythingbot/)
 

--- a/configs/template.js
+++ b/configs/template.js
@@ -30,7 +30,7 @@
         irc: {
             host: 'irc.freenode.net',
             user: 'UnconfiguredBot',
-            channel: '#botwillacceptanything',
+            channel: '#anythingbot',
         },
         */
        voting: {


### PR DESCRIPTION
Switching to a new channel with op has been discussed in IRC and in #423.

The primary reason we would want to switch channels is to open the doors to more IRC functionality in the bot in the future. This could be voicing users that have submitted a merged PR, adjusting the topic to match the current vote status, or kicking users automatically if they meet a "bad user" criteria built into the bot. Changing the topic could be done right now, however we run the risk of anyone changing the title.

One of the larger reasons not to switch is a concern of losing users. The best ways to mitigate this would be to invite all of the current users to a new channel, switch all text on the bot to point to the new channel, change the topic to point to the new channel, and potentially set up a basic IRC bot to remind users about the new channel.