### PR TITLE
New version of Handlebars breaks the website

### DIFF
--- a/lib/middleware/publicViews.js
+++ b/lib/middleware/publicViews.js
@@ -18,7 +18,8 @@
             app.engine('.hbs', mustache({
                 defaultLayout: 'main',
                 extname: '.hbs',
-                layoutsDir: path.join(viewsDir, 'layouts')
+                layoutsDir: path.join(viewsDir, 'layouts'),
+                compilerOptions: undefined,
             }));
 
             // set views engine

--- a/lib/middleware/publicViews.js
+++ b/lib/middleware/publicViews.js
@@ -9,13 +9,13 @@
         'path'
     ];
 
-    define(deps, function(fs, mustache, path) {
+    define(deps, function(fs, exphbs, path) {
         function PublicViewsMiddleware(app) {
             var viewsDir = path.join(__dirname, '/../../data/views');
 
             app.set('views', viewsDir);
 
-            app.engine('.hbs', mustache({
+            app.engine('.hbs', exphbs({
                 defaultLayout: 'main',
                 extname: '.hbs',
                 layoutsDir: path.join(viewsDir, 'layouts'),


### PR DESCRIPTION
This applies a change from https://github.com/ericf/express-handlebars/issues/125, which will fix Handlebars and Express-Handlebars for fresh npm installs.