### PR TITLE
Remove Part Message on IRC

### DIFF
--- a/lib/integrations/irc.js
+++ b/lib/integrations/irc.js
@@ -78,14 +78,6 @@
                     }
                 }
             });
-            client.on('part', function(channel, nick, reason) {
-                if(channel == config.irc.channel) {
-                    if(conversations[nick] !== undefined) {
-                        conversations[nick] = undefined;
-                        client.say(channel, "Goodbye, " + nick + ", :'(");
-                    }
-                }
-            });
             client.on('join' + config.irc.channel, function (nick) {
                 checkInitNewConversation(nick);
                 if (nick !== config.irc.user) { return; }


### PR DESCRIPTION
Since it isn't even seen by the person leaving, why have it?