### PR TITLE
Update voteEnded.md: hint that "stargazers" is a term/attribute

### DIFF
--- a/data/templates/voting/voteEnded.md
+++ b/data/templates/voting/voteEnded.md
@@ -8,12 +8,12 @@
 
 {{#nonStarGazers}}
     {{#first}}
-These following {{nonStarGazers.length}} voter(s) were not stargazers, so their votes were not counted:
+These following {{nonStarGazers.length}} voter(s) were not _stargazers_, so their votes were not counted:
     {{/first}}
 
 - :monkey: @{{name}}
 
     {{#last}}
-Be sure to :star:star the repository if you want to have your say!
+*Non-stargazers*: Be sure to :star:star the repository if you want to have your say!
     {{/last}}
 {{/nonStarGazers}}


### PR DESCRIPTION
"Stargazers" is gitub lingo, and its special github meaning is not immediatly apparent. The first use of the word was italicised, and the call to action to become a stargazer was emphasised