### PR TITLE
Decrement minVotes (8 -> 7)

### DIFF
--- a/configs/template.js
+++ b/configs/template.js
@@ -37,7 +37,7 @@
        voting: {
          period: 15,
          period_jitter: 0.2,
-         minVotes: 8,
+         minVotes: 7,
          supermajority: 0.65,
          pollInterval: 3, // Minutes
        },


### PR DESCRIPTION
I think the correct solution is to make it easier to adjust the minVotes, or let it cycle throughout the day, or adjust dynamically; development has cooled off from the overheated burst of activity, since commit 199.

Note that this only adjusts the template (it doesn't do anything, it is just a statement by the team that the team would like to adjust the voting parameters, the sysadmin has to make the change in the configs that are loaded).

If the team wants direct control over minVotes instead of indirect control that is another PR (the way it is currently set up, the sysadmin has veto power over changes to minVotes because minVotes lives in the configs).