### PR TITLE
Correct IP Logging

### DIFF
--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -25,6 +25,7 @@
 
         module.exports = function (config) {
             var app = express();
+            app.enable('trust proxy'), 
 
             // Pass config to every view
             app.use(function (req, res, next) {


### PR DESCRIPTION
Express is told that the proxy is to be trusted. X-Forwarded-For Headers will now be used for the log