### PR TITLE
Propose self-hosting idea

### DIFF
--- a/ideas.md
+++ b/ideas.md
@@ -19,3 +19,4 @@
  - [ ] IRC Bot updates the title of the IRC chatroom with the GitHub vote status.
  - [ ] Use the [uptimerobot.com API](http://uptimerobot.com/api) (not the npm package (outdated)) to fetch statistics about average ping time and bot uptime (API Key: m776770188-f669ffb04faa51274eb730b2 | Monitor ID: 776770188)
  - [ ] Give the bot enough brains to read email
+ - [ ] Make the bot self-hosting (i.e. not dependent on github.com)


### PR DESCRIPTION
The anythingbot can, in theory, manage the entire pull request proposal-vote-merge process with its own web interface. The impetus for this idea comes from two events in the recent past:

(1) The sourceforge fiasco (google: sourceforge gimp)

(2) The appearance of GitTorrent, or rather, the appearance of the *idea* of a decentralized version of github, or rather, the idea that it is OK to be paranoid when a single domain is the host of a large number of open source projects, just like it is OK to be paranoid when an elephant starts walking across an ice lake...

http://blog.printf.net/articles/2015/05/29/announcing-gittorrent-a-decentralized-github/
https://news.ycombinator.com/item?id=9625840

Some remarks. (A) The idea of github becoming "the Facebook of open source" gives me the heebie jeebies ( http://en.wikipedia.org/wiki/Heebie-jeebies_%28idiom%29 ). (B) As noted in the printf.net blog, git already is decentralized...what is missing was web-based socially-networked workflow tools, which is what github.com developed. Now everybody is used to using the same web-based git workflow tools.

There is nothing stopping the anythingbot from "lifting" the github workflow. The user interaction can be written down as a spec and then re-implemented. If the bot acquires a few other things (like https, which allows the bot to create user accounts; verifying emails; and precautions against vandalism / attempting to get the bot to execute malicious code) it should be possible to replicate the full github experience (including voting) on botwillacceptanything.com or anythingbot.org, making the bot truly self-hosting.

Creating a "genuine fork" which is to say "a fork that renames the bot" (as opposed to a fork you make to add a feature to the anythingbot) is then a matter of (1) purchasing a domain name and linode (2) cloning the repo to the linode (3) telling the bot the new domain it's hosted on. So for example it would be possible for the anythingbot to fork into the "mediabot" or "cryptobot" at {mediabot,cryptobot}.{com,org,net}.

So each bot would be independent, self-hosting, and would accept PRs according to an algorithmic law (or a semi-algorithmic law according to what kind of "development constitution" the domain owner wants).

Now, the skynet scenario is: a time traveler uploads code that gives the bot human-like intelligence, and one bot starts submitting PRs to another bot, and those two bots start submitting PRs and voting on code for a third bot...

![](http://picayune.uclick.com/comics/ch/1990/ch900117.gif)
